### PR TITLE
QML instead of OpenGL

### DIFF
--- a/app/Joker/Joker.pro
+++ b/app/Joker/Joker.pro
@@ -9,7 +9,7 @@ cache()
 TARGET = Joker
 TEMPLATE = app
 
-QT += core gui
+QT += core gui qml quick quickwidgets
 
 # The application version
 VERSION = 1.1.15
@@ -60,6 +60,10 @@ FORMS += \
 	PeopleDialog.ui \
 	PeopleEditionDialog.ui \
 	RulerSpaceDialog.ui
+
+
+RESOURCES += \
+    Joker.qrc
 
 unix {
 	QMAKE_POST_LINK += sed -E -i \"\" -e \"s/\(PROJECT_NUMBER[ ]*=[ ]*\)[^ ]*/\1$$VERSION/\" \"$${JOKER_ROOT}/.doxygen\";

--- a/app/Joker/Joker.pro
+++ b/app/Joker/Joker.pro
@@ -94,7 +94,7 @@ QMAKE_POST_LINK += $${QMAKE_COPY} $$shell_path($${JOKER_ROOT}/app/Joker/Video.qm
 QMAKE_POST_LINK += $${QMAKE_COPY} $$shell_path($${JOKER_ROOT}/app/Joker/Strip.qml) $${RESOURCES_PATH} $${CS}
 QMAKE_POST_LINK += $${QMAKE_COPY} $$shell_path($${JOKER_ROOT}/app/Joker/LeftColumn.qml) $${RESOURCES_PATH} $${CS}
 QMAKE_POST_LINK += $${QMAKE_COPY} $$shell_path($${JOKER_ROOT}/app/Joker/RightColumn.qml) $${RESOURCES_PATH} $${CS}
-
+QMAKE_POST_LINK += $${QMAKE_COPY} $$shell_path($${JOKER_ROOT}/app/Joker/MediaPanel.qml) $${RESOURCES_PATH} $${CS}
 
 TRANSLATIONS =	fr_FR.ts \
 
@@ -110,4 +110,5 @@ OTHER_FILES += \
     RightColumn.qml \
     LeftColumn.qml \
     Strip.qml \
-    Video.qml
+    Video.qml \
+    MediaPanel.qml

--- a/app/Joker/Joker.pro
+++ b/app/Joker/Joker.pro
@@ -89,13 +89,6 @@ QMAKE_POST_LINK += $${QMAKE_COPY} $$shell_path($${JOKER_ROOT}/data/img/motif-240
 QMAKE_POST_LINK += $${QMAKE_COPY} $$shell_path($${JOKER_ROOT}/data/fonts/SWENSON.TTF) $${RESOURCES_PATH} $${CS}
 QMAKE_POST_LINK += $${QMAKE_COPY} $$shell_path($${JOKER_ROOT}/data/fonts/HelveticaCYPlain.ttf) $${RESOURCES_PATH} $${CS}
 
-QMAKE_POST_LINK += $${QMAKE_COPY} $$shell_path($${JOKER_ROOT}/app/Joker/main.qml) $${RESOURCES_PATH} $${CS}
-QMAKE_POST_LINK += $${QMAKE_COPY} $$shell_path($${JOKER_ROOT}/app/Joker/Video.qml) $${RESOURCES_PATH} $${CS}
-QMAKE_POST_LINK += $${QMAKE_COPY} $$shell_path($${JOKER_ROOT}/app/Joker/Strip.qml) $${RESOURCES_PATH} $${CS}
-QMAKE_POST_LINK += $${QMAKE_COPY} $$shell_path($${JOKER_ROOT}/app/Joker/LeftColumn.qml) $${RESOURCES_PATH} $${CS}
-QMAKE_POST_LINK += $${QMAKE_COPY} $$shell_path($${JOKER_ROOT}/app/Joker/RightColumn.qml) $${RESOURCES_PATH} $${CS}
-QMAKE_POST_LINK += $${QMAKE_COPY} $$shell_path($${JOKER_ROOT}/app/Joker/MediaPanel.qml) $${RESOURCES_PATH} $${CS}
-
 TRANSLATIONS =	fr_FR.ts \
 
 QMAKE_POST_LINK += lrelease $${_PRO_FILE_PWD_}/fr_FR.ts -qm $${RESOURCES_PATH}/fr_FR.qm $${CS}
@@ -112,3 +105,6 @@ OTHER_FILES += \
     Strip.qml \
     Video.qml \
     MediaPanel.qml
+
+RESOURCES += \
+    JokerResources.qrc

--- a/app/Joker/Joker.pro
+++ b/app/Joker/Joker.pro
@@ -61,10 +61,6 @@ FORMS += \
 	PeopleEditionDialog.ui \
 	RulerSpaceDialog.ui
 
-
-RESOURCES += \
-    Joker.qrc
-
 unix {
 	QMAKE_POST_LINK += sed -E -i \"\" -e \"s/\(PROJECT_NUMBER[ ]*=[ ]*\)[^ ]*/\1$$VERSION/\" \"$${JOKER_ROOT}/.doxygen\";
 }
@@ -93,6 +89,12 @@ QMAKE_POST_LINK += $${QMAKE_COPY} $$shell_path($${JOKER_ROOT}/data/img/motif-240
 QMAKE_POST_LINK += $${QMAKE_COPY} $$shell_path($${JOKER_ROOT}/data/fonts/SWENSON.TTF) $${RESOURCES_PATH} $${CS}
 QMAKE_POST_LINK += $${QMAKE_COPY} $$shell_path($${JOKER_ROOT}/data/fonts/HelveticaCYPlain.ttf) $${RESOURCES_PATH} $${CS}
 
+QMAKE_POST_LINK += $${QMAKE_COPY} $$shell_path($${JOKER_ROOT}/app/Joker/main.qml) $${RESOURCES_PATH} $${CS}
+QMAKE_POST_LINK += $${QMAKE_COPY} $$shell_path($${JOKER_ROOT}/app/Joker/Video.qml) $${RESOURCES_PATH} $${CS}
+QMAKE_POST_LINK += $${QMAKE_COPY} $$shell_path($${JOKER_ROOT}/app/Joker/Strip.qml) $${RESOURCES_PATH} $${CS}
+QMAKE_POST_LINK += $${QMAKE_COPY} $$shell_path($${JOKER_ROOT}/app/Joker/LeftColumn.qml) $${RESOURCES_PATH} $${CS}
+QMAKE_POST_LINK += $${QMAKE_COPY} $$shell_path($${JOKER_ROOT}/app/Joker/RightColumn.qml) $${RESOURCES_PATH} $${CS}
+
 
 TRANSLATIONS =	fr_FR.ts \
 
@@ -102,3 +104,10 @@ PH_DEPLOY_LOCATION = $$(JOKER_RELEASE_PATH)
 include(../../common/deploy.pri)
 
 cache()
+
+OTHER_FILES += \
+    main.qml \
+    RightColumn.qml \
+    LeftColumn.qml \
+    Strip.qml \
+    Video.qml

--- a/app/Joker/Joker.pro
+++ b/app/Joker/Joker.pro
@@ -9,7 +9,7 @@ cache()
 TARGET = Joker
 TEMPLATE = app
 
-QT += core gui qml quick quickwidgets
+QT += core gui qml quick quickwidgets multimedia
 
 # The application version
 VERSION = 1.1.15

--- a/app/Joker/Joker.qrc
+++ b/app/Joker/Joker.qrc
@@ -1,5 +1,8 @@
 <RCC>
     <qresource prefix="/Phonations/Joker">
         <file>main.qml</file>
+        <file>Video.qml</file>
+        <file>LeftColumn.qml</file>
+        <file>RightColumn.qml</file>
     </qresource>
 </RCC>

--- a/app/Joker/Joker.qrc
+++ b/app/Joker/Joker.qrc
@@ -4,5 +4,6 @@
         <file>Video.qml</file>
         <file>LeftColumn.qml</file>
         <file>RightColumn.qml</file>
+        <file>Strip.qml</file>
     </qresource>
 </RCC>

--- a/app/Joker/Joker.qrc
+++ b/app/Joker/Joker.qrc
@@ -1,0 +1,5 @@
+<RCC>
+    <qresource prefix="/Phonations/Joker">
+        <file>main.qml</file>
+    </qresource>
+</RCC>

--- a/app/Joker/JokerResources.qrc
+++ b/app/Joker/JokerResources.qrc
@@ -1,0 +1,10 @@
+<RCC>
+    <qresource prefix="/">
+        <file>LeftColumn.qml</file>
+        <file>main.qml</file>
+        <file>MediaPanel.qml</file>
+        <file>RightColumn.qml</file>
+        <file>Strip.qml</file>
+        <file>Video.qml</file>
+    </qresource>
+</RCC>

--- a/app/Joker/JokerWindow.cpp
+++ b/app/Joker/JokerWindow.cpp
@@ -37,6 +37,8 @@ JokerWindow::JokerWindow(JokerSettings *settings) :
 	_resizingStrip(false),
 	_numberOfDraw(0)
 {
+	qApp->installEventFilter(this);
+
 	// Setting up UI
 	ui->setupUi(this);
 

--- a/app/Joker/JokerWindow.cpp
+++ b/app/Joker/JokerWindow.cpp
@@ -886,20 +886,19 @@ void JokerWindow::onPaint(int width, int height)
 	PhClock *clock = _videoEngine.clock();
 	long delay = (int)(24 * _settings->screenDelay() * clock->rate());
 	PhTime clockTime = clock->time() + delay;
-	int tcHeight = tcWidth / 5;
+
+	QQuickItem *tcLabel = ui->videoStripView->rootObject()->findChild<QQuickItem*>("tcLabel");
+	tcLabel->setVisible(_settings->displayTC());
+	tcLabel->setProperty("text", PhTimeCode::stringFromTime(clockTime, _videoEngine.timeCodeType()));
 
 	int tcOffset = 0;
 	if(_settings->displayNextTC())
-		tcOffset = tcHeight;
+		tcOffset = tcLabel->height();
 
 	_strip.draw(0, y + videoHeight, width, stripHeight, tcOffset, selectedPeoples);
 	foreach(QString info, _strip.infos()) {
 		ui->videoStripView->addInfo(info);
 	}
-
-	QQuickItem *tcLabel = ui->videoStripView->rootObject()->findChild<QQuickItem*>("tcLabel");
-	tcLabel->setVisible(_settings->displayTC());
-	tcLabel->setProperty("text", PhTimeCode::stringFromTime(clockTime, _videoEngine.timeCodeType()));
 
 	PhStripText *nextText = NULL;
 	if(_settings->displayNextTC()) {

--- a/app/Joker/JokerWindow.cpp
+++ b/app/Joker/JokerWindow.cpp
@@ -52,6 +52,10 @@ JokerWindow::JokerWindow(JokerSettings *settings) :
 	ui->videoStripView->engine()->rootContext()->setContextProperty("selectedPeopleModel", QVariant::fromValue(_selectedPeopleList));
 	ui->videoStripView->engine()->rootContext()->setContextProperty("infoModel", QVariant::fromValue(_infoList));
 	ui->videoStripView->engine()->rootContext()->setContextProperty("nextPeopleModel", _strip.nextPeopleModel());
+	ui->videoStripView->engine()->rootContext()->setContextProperty("stripTextModelTrack0", _strip.stripTextModelTrack0());
+	ui->videoStripView->engine()->rootContext()->setContextProperty("stripTextModelTrack1", _strip.stripTextModelTrack1());
+	ui->videoStripView->engine()->rootContext()->setContextProperty("stripTextModelTrack2", _strip.stripTextModelTrack2());
+	ui->videoStripView->engine()->rootContext()->setContextProperty("stripTextModelTrack3", _strip.stripTextModelTrack3());
 	ui->videoStripView->engine()->rootContext()->setContextProperty("verticalTimePerPixel", _settings->verticalTimePerPixel());
 	ui->videoStripView->engine()->rootContext()->setContextProperty("horizontalTimePerPixel", _settings->horizontalTimePerPixel());
 
@@ -907,15 +911,6 @@ void JokerWindow::onPaint(int width, int height)
 		tcOffset = tcLabel->height();
 
 	_strip.draw(0, y + videoHeight, width, stripHeight, tcOffset, selectedPeoples);
-
-	QList<QObject*> stripTexts;
-	foreach(PhStripText *text, _strip.stripTexts()) {
-		stripTexts.append(text);
-	}
-
-	// refresh the view
-	// TODO the view could be refreshed more intelligently by defining a true model and define change signals
-	ui->videoStripView->engine()->rootContext()->setContextProperty("stripTextModel", QVariant::fromValue(stripTexts));
 
 	// prepare the string list that is used to display the infos
 	_infoList.clear();

--- a/app/Joker/JokerWindow.cpp
+++ b/app/Joker/JokerWindow.cpp
@@ -57,6 +57,10 @@ JokerWindow::JokerWindow(JokerSettings *settings) :
 	ui->videoStripView->engine()->rootContext()->setContextProperty("stripTextModelTrack1", _strip.stripTextModelTrack1());
 	ui->videoStripView->engine()->rootContext()->setContextProperty("stripTextModelTrack2", _strip.stripTextModelTrack2());
 	ui->videoStripView->engine()->rootContext()->setContextProperty("stripTextModelTrack3", _strip.stripTextModelTrack3());
+	ui->videoStripView->engine()->rootContext()->setContextProperty("stripPeopleModelTrack0", _strip.stripPeopleModelTrack0());
+	ui->videoStripView->engine()->rootContext()->setContextProperty("stripPeopleModelTrack1", _strip.stripPeopleModelTrack1());
+	ui->videoStripView->engine()->rootContext()->setContextProperty("stripPeopleModelTrack2", _strip.stripPeopleModelTrack2());
+	ui->videoStripView->engine()->rootContext()->setContextProperty("stripPeopleModelTrack3", _strip.stripPeopleModelTrack3());
 	ui->videoStripView->engine()->rootContext()->setContextProperty("verticalTimePerPixel", _settings->verticalTimePerPixel());
 	ui->videoStripView->engine()->rootContext()->setContextProperty("horizontalTimePerPixel", _settings->horizontalTimePerPixel());
 	ui->videoStripView->engine()->rootContext()->setContextProperty("textFontUrl", QUrl::fromLocalFile(_settings->textFontFile()));

--- a/app/Joker/JokerWindow.cpp
+++ b/app/Joker/JokerWindow.cpp
@@ -897,13 +897,9 @@ void JokerWindow::onPaint(int width, int height)
 		ui->videoStripView->addInfo(info);
 	}
 
-	if(_settings->displayTC()) {
-		PhGraphicText tcText(_strip.getHUDFont());
-		tcText.setColor(Qt::green);
-		tcText.setRect(0, y, tcWidth, tcHeight);
-		tcText.setContent(PhTimeCode::stringFromTime(clockTime, _videoEngine.timeCodeType()));
-		tcText.draw();
-	}
+	QQuickItem *tcLabel = ui->videoStripView->rootObject()->findChild<QQuickItem*>("tcLabel");
+	tcLabel->setVisible(_settings->displayTC());
+	tcLabel->setProperty("text", PhTimeCode::stringFromTime(clockTime, _videoEngine.timeCodeType()));
 
 	if(_settings->displayNextTC()) {
 		PhStripText *nextText = NULL;

--- a/app/Joker/JokerWindow.cpp
+++ b/app/Joker/JokerWindow.cpp
@@ -559,7 +559,7 @@ void JokerWindow::on_actionPreferences_triggered()
 void JokerWindow::fadeInMediaPanel()
 {
 	// Don't show the mediaPanel if Joker has not thefocus.
-	if(!this->hasFocus())
+	if(!(this->hasFocus() || ui->videoStripView->hasFocus()))
 		return;
 	// Don't show the mediaPanel if Joker is remote controled.
 	if(_settings->synchroProtocol() != PhSynchronizer::NoSync)

--- a/app/Joker/JokerWindow.cpp
+++ b/app/Joker/JokerWindow.cpp
@@ -835,7 +835,7 @@ void JokerWindow::onPaint(int width, int height)
 
 	// refresh the view
 	// TODO the view could be refreshed more intelligently by connecting to the signals of the people selection dialog
-	ui->videoStripView->engine()->rootContext()->setContextProperty("selectedPeopleModel", QVariant::fromValue(_selectedPeopleList));
+	//ui->videoStripView->engine()->rootContext()->setContextProperty("selectedPeopleModel", QVariant::fromValue(_selectedPeopleList));
 
 	int y = 0;
 
@@ -922,15 +922,15 @@ void JokerWindow::onPaint(int width, int height)
 	// TODO the view could be refreshed more intelligently by defining a true model and define change signals
 	ui->videoStripView->engine()->rootContext()->setContextProperty("nextPeopleModel", QVariant::fromValue(_nextPeoples));
 
+	if (_stripTexts.empty() && !_strip.stripTexts().empty()) {
+		foreach(PhStripText *text, _strip.stripTexts()) {
+			_stripTexts.append(text);
+		}
 
-	QList<QObject*> stripTexts;
-	foreach(PhStripText *text, _strip.stripTexts()) {
-		stripTexts.append(text);
+		// refresh the view
+		// TODO the view could be refreshed more intelligently by defining a true model and define change signals
+		ui->videoStripView->engine()->rootContext()->setContextProperty("stripTextModel", QVariant::fromValue(_stripTexts));
 	}
-
-	// refresh the view
-	// TODO the view could be refreshed more intelligently by defining a true model and define change signals
-	ui->videoStripView->engine()->rootContext()->setContextProperty("stripTextModel", QVariant::fromValue(stripTexts));
 
 	// prepare the string list that is used to display the infos
 	_infoList.clear();
@@ -950,7 +950,7 @@ void JokerWindow::onPaint(int width, int height)
 		_infoList.append(info);
 	}
 
-	ui->videoStripView->engine()->rootContext()->setContextProperty("infoModel", QVariant::fromValue(_infoList));
+	//ui->videoStripView->engine()->rootContext()->setContextProperty("infoModel", QVariant::fromValue(_infoList));
 	QQuickItem *infoList = ui->videoStripView->rootObject()->findChild<QQuickItem*>("infoList");
 	infoList->setVisible(_settings->displayInfo());
 

--- a/app/Joker/JokerWindow.cpp
+++ b/app/Joker/JokerWindow.cpp
@@ -50,6 +50,10 @@ JokerWindow::JokerWindow(JokerSettings *settings) :
 	ui->videoStripView->engine()->rootContext()->setContextProperty("jokerWindow", this);
 	ui->videoStripView->engine()->rootContext()->setContextProperty("selectedPeopleModel", QVariant::fromValue(_selectedPeopleList));
 	ui->videoStripView->engine()->rootContext()->setContextProperty("infoModel", QVariant::fromValue(_infoList));
+	ui->videoStripView->engine()->rootContext()->setContextProperty("nextPeopleModel", QVariant::fromValue(_nextPeoples));
+	ui->videoStripView->engine()->rootContext()->setContextProperty("verticalTimePerPixel", _settings->verticalTimePerPixel());
+	ui->videoStripView->engine()->rootContext()->setContextProperty("clockTime", _strip.clock()->time() + _settings->screenDelay());
+
 
 	ui->videoStripView->setResizeMode(QQuickWidget::SizeRootObjectToView);
 	ui->videoStripView->setSource(QUrl("qrc:///Phonations/Joker/main.qml"));
@@ -888,7 +892,6 @@ void JokerWindow::onPaint(int width, int height)
 
 	QQuickItem *videoLogo = ui->videoStripView->rootObject()->findChild<QQuickItem*>("videoLogo");
 	videoLogo->setVisible((videoHeight > 0) && (_videoEngine.height() <= 0) && _settings->displayLogo());
-	videoLogo->setHeight(videoHeight);
 
 	PhClock *clock = _videoEngine.clock();
 	long delay = (int)(24 * _settings->screenDelay() * clock->rate());
@@ -903,6 +906,21 @@ void JokerWindow::onPaint(int width, int height)
 		tcOffset = tcLabel->height();
 
 	_strip.draw(0, y + videoHeight, width, stripHeight, tcOffset, selectedPeoples);
+
+	ui->videoStripView->engine()->rootContext()->setContextProperty("clockTime", _strip.clock()->time() + _settings->screenDelay());
+
+	// Note: _selectedPeopleList is needed because QVariant does not know how to handle a QList<PhPeople*>
+	// we convert it to QList<QObject*>
+	ui->videoStripView->engine()->rootContext()->setContextProperty("nextPeopleModel", NULL);
+	qDeleteAll(_nextPeoples);
+	_nextPeoples.clear();
+	foreach(PhNextPeople *nextPeople, _strip.nextPeoples()) {
+		_nextPeoples.append(nextPeople);
+	}
+
+	// refresh the view
+	// TODO the view could be refreshed more intelligently by defining a true model and define change signals
+	ui->videoStripView->engine()->rootContext()->setContextProperty("nextPeopleModel", QVariant::fromValue(_nextPeoples));
 
 	// prepare the string list that is used to display the infos
 	_infoList.clear();
@@ -953,9 +971,10 @@ void JokerWindow::onPaint(int width, int height)
 
 	PhStripLoop * currentLoop = _strip.doc()->previousLoop(clockTime);
 	setCurrentLoopLabel(currentLoop ? currentLoop->label(): "");
-	QQuickItem *loopLabel = ui->videoStripView->rootObject()->findChild<QQuickItem*>("currentLoopLabel");
-	// if the strip was drawn with QML too, the following could be replaced with proper anchoring
-	loopLabel->setY(height - stripHeight - loopLabel->height());
+
+	// placeholder used to position other UI elements
+	QQuickItem *stripPlaceholder = ui->videoStripView->rootObject()->findChild<QQuickItem*>("stripPlaceholder");
+	stripPlaceholder->setHeight(stripHeight);
 
 	QQuickItem *noSyncLabel = ui->videoStripView->rootObject()->findChild<QQuickItem*>("noSyncLabel");
 	noSyncLabel->setVisible(_lastVideoSyncElapsed.elapsed() > 1000);

--- a/app/Joker/JokerWindow.cpp
+++ b/app/Joker/JokerWindow.cpp
@@ -860,10 +860,14 @@ void JokerWindow::onPaint(int width, int height)
 			_videoEngine.drawVideo(videoX, y + blackStripHeight, videoWidth, realVideoHeight);
 
 			// adjust tc size
-			if(videoX > tcWidth)
+			// FIXME this does not work now that QML is used for the timecode labels.
+			if(videoX > tcWidth) {
+				// maximize the timecode if we have more room
 				tcWidth = videoX;
-			else if( width < 2 * tcWidth)
+			} else if( width < 2 * tcWidth) {
+				// make sure the timecode labels do not overlap
 				tcWidth = width / 2;
+			}
 		}
 		else if(_settings->displayLogo()) {
 			// The logo file is 500px in native format

--- a/app/Joker/JokerWindow.cpp
+++ b/app/Joker/JokerWindow.cpp
@@ -835,7 +835,7 @@ void JokerWindow::onPaint(int width, int height)
 
 	// refresh the view
 	// TODO the view could be refreshed more intelligently by connecting to the signals of the people selection dialog
-	//ui->videoStripView->engine()->rootContext()->setContextProperty("selectedPeopleModel", QVariant::fromValue(_selectedPeopleList));
+	ui->videoStripView->engine()->rootContext()->setContextProperty("selectedPeopleModel", QVariant::fromValue(_selectedPeopleList));
 
 	int y = 0;
 
@@ -922,15 +922,15 @@ void JokerWindow::onPaint(int width, int height)
 	// TODO the view could be refreshed more intelligently by defining a true model and define change signals
 	ui->videoStripView->engine()->rootContext()->setContextProperty("nextPeopleModel", QVariant::fromValue(_nextPeoples));
 
-	if (_stripTexts.empty() && !_strip.stripTexts().empty()) {
-		foreach(PhStripText *text, _strip.stripTexts()) {
-			_stripTexts.append(text);
-		}
 
-		// refresh the view
-		// TODO the view could be refreshed more intelligently by defining a true model and define change signals
-		ui->videoStripView->engine()->rootContext()->setContextProperty("stripTextModel", QVariant::fromValue(_stripTexts));
+	QList<QObject*> stripTexts;
+	foreach(PhStripText *text, _strip.stripTexts()) {
+		stripTexts.append(text);
 	}
+
+	// refresh the view
+	// TODO the view could be refreshed more intelligently by defining a true model and define change signals
+	ui->videoStripView->engine()->rootContext()->setContextProperty("stripTextModel", QVariant::fromValue(stripTexts));
 
 	// prepare the string list that is used to display the infos
 	_infoList.clear();
@@ -950,7 +950,7 @@ void JokerWindow::onPaint(int width, int height)
 		_infoList.append(info);
 	}
 
-	//ui->videoStripView->engine()->rootContext()->setContextProperty("infoModel", QVariant::fromValue(_infoList));
+	ui->videoStripView->engine()->rootContext()->setContextProperty("infoModel", QVariant::fromValue(_infoList));
 	QQuickItem *infoList = ui->videoStripView->rootObject()->findChild<QQuickItem*>("infoList");
 	infoList->setVisible(_settings->displayInfo());
 

--- a/app/Joker/JokerWindow.cpp
+++ b/app/Joker/JokerWindow.cpp
@@ -37,7 +37,8 @@ JokerWindow::JokerWindow(JokerSettings *settings) :
 	_mediaPanelAnimation(&_mediaPanel, "windowOpacity"),
 	_firstDoc(true),
 	_resizingStrip(false),
-	_numberOfDraw(0)
+	_numberOfDraw(0),
+	_stripTime(0)
 {
 	qApp->installEventFilter(this);
 
@@ -52,7 +53,6 @@ JokerWindow::JokerWindow(JokerSettings *settings) :
 	ui->videoStripView->engine()->rootContext()->setContextProperty("infoModel", QVariant::fromValue(_infoList));
 	ui->videoStripView->engine()->rootContext()->setContextProperty("nextPeopleModel", _strip.nextPeopleModel());
 	ui->videoStripView->engine()->rootContext()->setContextProperty("verticalTimePerPixel", _settings->verticalTimePerPixel());
-	ui->videoStripView->engine()->rootContext()->setContextProperty("clockTime", _strip.clock()->time() + _settings->screenDelay());
 	ui->videoStripView->engine()->rootContext()->setContextProperty("horizontalTimePerPixel", _settings->horizontalTimePerPixel());
 
 	ui->videoStripView->setResizeMode(QQuickWidget::SizeRootObjectToView);
@@ -896,6 +896,7 @@ void JokerWindow::onPaint(int width, int height)
 	PhClock *clock = _videoEngine.clock();
 	long delay = (int)(24 * _settings->screenDelay() * clock->rate());
 	PhTime clockTime = clock->time() + delay;
+	setStripTime(clockTime);
 
 	QQuickItem *tcLabel = ui->videoStripView->rootObject()->findChild<QQuickItem*>("tcLabel");
 	tcLabel->setVisible(_settings->displayTC());
@@ -906,8 +907,6 @@ void JokerWindow::onPaint(int width, int height)
 		tcOffset = tcLabel->height();
 
 	_strip.draw(0, y + videoHeight, width, stripHeight, tcOffset, selectedPeoples);
-
-	ui->videoStripView->engine()->rootContext()->setContextProperty("clockTime", _strip.clock()->time() + _settings->screenDelay());
 
 	QList<QObject*> stripTexts;
 	foreach(PhStripText *text, _strip.stripTexts()) {
@@ -1018,5 +1017,18 @@ void JokerWindow::setCurrentLoopLabel(QString label)
 	if (label != _currentLoopLabel) {
 		_currentLoopLabel = label;
 		emit currentLoopLabelChanged();
+	}
+}
+
+PhTime JokerWindow::stripTime()
+{
+	return _stripTime;
+}
+
+void JokerWindow::setStripTime(PhTime time)
+{
+	if (time != _stripTime) {
+		_stripTime = time;
+		emit stripTimeChanged();
 	}
 }

--- a/app/Joker/JokerWindow.cpp
+++ b/app/Joker/JokerWindow.cpp
@@ -54,14 +54,7 @@ JokerWindow::JokerWindow(JokerSettings *settings) :
 	ui->videoStripView->engine()->rootContext()->setContextProperty("rulerModel", _strip.rulerModel());
 	ui->videoStripView->engine()->rootContext()->setContextProperty("cutModel", _strip.cutModel());
 	ui->videoStripView->engine()->rootContext()->setContextProperty("loopModel", _strip.loopModel());
-	ui->videoStripView->engine()->rootContext()->setContextProperty("stripTextModelTrack0", _strip.stripTextModelTrack0());
-	ui->videoStripView->engine()->rootContext()->setContextProperty("stripTextModelTrack1", _strip.stripTextModelTrack1());
-	ui->videoStripView->engine()->rootContext()->setContextProperty("stripTextModelTrack2", _strip.stripTextModelTrack2());
-	ui->videoStripView->engine()->rootContext()->setContextProperty("stripTextModelTrack3", _strip.stripTextModelTrack3());
-	ui->videoStripView->engine()->rootContext()->setContextProperty("stripPeopleModelTrack0", _strip.stripPeopleModelTrack0());
-	ui->videoStripView->engine()->rootContext()->setContextProperty("stripPeopleModelTrack1", _strip.stripPeopleModelTrack1());
-	ui->videoStripView->engine()->rootContext()->setContextProperty("stripPeopleModelTrack2", _strip.stripPeopleModelTrack2());
-	ui->videoStripView->engine()->rootContext()->setContextProperty("stripPeopleModelTrack3", _strip.stripPeopleModelTrack3());
+	ui->videoStripView->engine()->rootContext()->setContextProperty("trackModel", _strip.trackModel());
 	ui->videoStripView->engine()->rootContext()->setContextProperty("verticalTimePerPixel", _settings->verticalTimePerPixel());
 	ui->videoStripView->engine()->rootContext()->setContextProperty("horizontalTimePerPixel", _settings->horizontalTimePerPixel());
 	ui->videoStripView->engine()->rootContext()->setContextProperty("textFontUrl", QUrl::fromLocalFile(_settings->textFontFile()));

--- a/app/Joker/JokerWindow.cpp
+++ b/app/Joker/JokerWindow.cpp
@@ -57,6 +57,7 @@ JokerWindow::JokerWindow(JokerSettings *settings) :
 	ui->videoStripView->engine()->rootContext()->setContextProperty("stripTextModelTrack3", _strip.stripTextModelTrack3());
 	ui->videoStripView->engine()->rootContext()->setContextProperty("verticalTimePerPixel", _settings->verticalTimePerPixel());
 	ui->videoStripView->engine()->rootContext()->setContextProperty("horizontalTimePerPixel", _settings->horizontalTimePerPixel());
+	ui->videoStripView->engine()->rootContext()->setContextProperty("textFontUrl", QUrl::fromLocalFile(_settings->textFontFile()));
 
 	ui->videoStripView->setResizeMode(QQuickWidget::SizeRootObjectToView);
 	ui->videoStripView->setSource(QUrl("qrc:///Phonations/Joker/main.qml"));

--- a/app/Joker/JokerWindow.cpp
+++ b/app/Joker/JokerWindow.cpp
@@ -131,6 +131,8 @@ JokerWindow::JokerWindow(JokerSettings *settings) :
 	this->connect(OpenGLView, &PhQmlView::paint, this, &JokerWindow::onPaint, Qt::DirectConnection);
 
 	_videoLogo.setFilename(QCoreApplication::applicationDirPath() + PATH_TO_RESSOURCES + "/phonations.png");
+	QQuickItem *videoLogo = ui->videoStripView->rootObject()->findChild<QQuickItem*>("videoLogo");
+	videoLogo->setProperty("source", QUrl::fromLocalFile(QCoreApplication::applicationDirPath() + PATH_TO_RESSOURCES + "/phonations.png"));
 }
 
 JokerWindow::~JokerWindow()
@@ -869,23 +871,11 @@ void JokerWindow::onPaint(int width, int height)
 				tcWidth = width / 2;
 			}
 		}
-		else if(_settings->displayLogo()) {
-			// The logo file is 500px in native format
-			int logoHeight = _videoLogo.originalSize().height();
-			int logoWidth = _videoLogo.originalSize().width();
-			if(videoHeight < logoHeight) {
-				logoHeight = videoHeight;
-				logoWidth = _videoLogo.originalSize().width() * logoHeight / _videoLogo.originalSize().height();
-			}
-			if(width < logoWidth) {
-				logoWidth = width;
-				logoHeight = _videoLogo.originalSize().height() * logoWidth / _videoLogo.originalSize().width();
-			}
-			_videoLogo.setRect((width - logoHeight) / 2, (videoHeight - logoHeight) / 2, logoHeight, logoHeight);
-			_videoLogo.draw();
-
-		}
 	}
+
+	QQuickItem *videoLogo = ui->videoStripView->rootObject()->findChild<QQuickItem*>("videoLogo");
+	videoLogo->setVisible((videoHeight > 0) && (_videoEngine.height() <= 0) && _settings->displayLogo());
+	videoLogo->setHeight(videoHeight);
 
 	PhClock *clock = _videoEngine.clock();
 	long delay = (int)(24 * _settings->screenDelay() * clock->rate());

--- a/app/Joker/JokerWindow.cpp
+++ b/app/Joker/JokerWindow.cpp
@@ -58,6 +58,7 @@ JokerWindow::JokerWindow(JokerSettings *settings) :
 	ui->videoStripView->engine()->rootContext()->setContextProperty("verticalTimePerPixel", _settings->verticalTimePerPixel());
 	ui->videoStripView->engine()->rootContext()->setContextProperty("horizontalTimePerPixel", _settings->horizontalTimePerPixel());
 	ui->videoStripView->engine()->rootContext()->setContextProperty("textFontUrl", QUrl::fromLocalFile(_settings->textFontFile()));
+	ui->videoStripView->engine()->rootContext()->setContextProperty("textBoldness", _settings->textBoldness());
 
 	ui->videoStripView->setResizeMode(QQuickWidget::SizeRootObjectToView);
 	ui->videoStripView->setSource(QUrl("qrc:///Phonations/Joker/main.qml"));

--- a/app/Joker/JokerWindow.cpp
+++ b/app/Joker/JokerWindow.cpp
@@ -16,6 +16,7 @@
 #include <QMouseEvent>
 #include <QQmlEngine>
 #include <QQuickView>
+#include <QQuickItem>
 
 #include "PhTools/PhDebug.h"
 #include "PhCommonUI/PhTimeCodeDialog.h"
@@ -86,9 +87,14 @@ JokerWindow::JokerWindow(JokerSettings *settings) :
 	_view->setResizeMode(QQuickView::SizeRootObjectToView);
 
 	// in resources or in full path, the qml sub-files are not found if launched from outside Qt Creator !
-	//_view->setSource(QUrl("qrc:///Phonations/Joker/main.qml"));
-	_view->setSource(QUrl::fromLocalFile(QCoreApplication::applicationDirPath() + PATH_TO_RESSOURCES + "/main.qml"));
+	_view->setSource(QUrl("qrc:///main.qml"));
+	//_view->setSource(QUrl::fromLocalFile(QCoreApplication::applicationDirPath() + PATH_TO_RESSOURCES + "/main.qml"));
 	_view->show();
+
+
+	QObject *button = _view->rootObject()->findChild<QObject *>("PlayButton");
+	// connect QML signal to C++ slot
+	QObject::connect(button, SIGNAL(clicked()), &_mediaPanel, SLOT(onPlayPause()));
 
 	// Due to translation, Qt might not be able to link automatically the menu
 	ui->actionPreferences->setMenuRole(QAction::PreferencesRole);

--- a/app/Joker/JokerWindow.cpp
+++ b/app/Joker/JokerWindow.cpp
@@ -51,6 +51,7 @@ JokerWindow::JokerWindow(JokerSettings *settings) :
 	ui->videoStripView->engine()->rootContext()->setContextProperty("jokerWindow", this);
 	ui->videoStripView->engine()->rootContext()->setContextProperty("selectedPeopleModel", &_selectedPeopleModel);
 	ui->videoStripView->engine()->rootContext()->setContextProperty("nextPeopleModel", _strip.nextPeopleModel());
+	ui->videoStripView->engine()->rootContext()->setContextProperty("rulerModel", _strip.rulerModel());
 	ui->videoStripView->engine()->rootContext()->setContextProperty("cutModel", _strip.cutModel());
 	ui->videoStripView->engine()->rootContext()->setContextProperty("loopModel", _strip.loopModel());
 	ui->videoStripView->engine()->rootContext()->setContextProperty("stripTextModelTrack0", _strip.stripTextModelTrack0());
@@ -68,6 +69,7 @@ JokerWindow::JokerWindow(JokerSettings *settings) :
 	ui->videoStripView->engine()->rootContext()->setContextProperty("cutWidth", _settings->cutWidth());
 	ui->videoStripView->engine()->rootContext()->setContextProperty("displayCuts", _settings->displayCuts());
 	ui->videoStripView->engine()->rootContext()->setContextProperty("invertColor", _settings->invertColor());
+	ui->videoStripView->engine()->rootContext()->setContextProperty("displayRuler", _settings->displayRuler());
 
 	ui->videoStripView->setResizeMode(QQuickWidget::SizeRootObjectToView);
 	ui->videoStripView->setSource(QUrl("qrc:///Phonations/Joker/main.qml"));

--- a/app/Joker/JokerWindow.cpp
+++ b/app/Joker/JokerWindow.cpp
@@ -90,10 +90,6 @@ JokerWindow::JokerWindow(JokerSettings *settings) :
 	_view->setSource(QUrl::fromLocalFile(QCoreApplication::applicationDirPath() + PATH_TO_RESSOURCES + "/main.qml"));
 	_view->show();
 
-	QMessageBox msgBox;
-	msgBox.setText(_view->engine()->importPathList().join(", "));
-	msgBox.exec();
-
 	// Due to translation, Qt might not be able to link automatically the menu
 	ui->actionPreferences->setMenuRole(QAction::PreferencesRole);
 	ui->actionAbout->setMenuRole(QAction::AboutRole);

--- a/app/Joker/JokerWindow.cpp
+++ b/app/Joker/JokerWindow.cpp
@@ -52,6 +52,7 @@ JokerWindow::JokerWindow(JokerSettings *settings) :
 	ui->videoStripView->engine()->rootContext()->setContextProperty("selectedPeopleModel", &_selectedPeopleModel);
 	ui->videoStripView->engine()->rootContext()->setContextProperty("nextPeopleModel", _strip.nextPeopleModel());
 	ui->videoStripView->engine()->rootContext()->setContextProperty("cutModel", _strip.cutModel());
+	ui->videoStripView->engine()->rootContext()->setContextProperty("loopModel", _strip.loopModel());
 	ui->videoStripView->engine()->rootContext()->setContextProperty("stripTextModelTrack0", _strip.stripTextModelTrack0());
 	ui->videoStripView->engine()->rootContext()->setContextProperty("stripTextModelTrack1", _strip.stripTextModelTrack1());
 	ui->videoStripView->engine()->rootContext()->setContextProperty("stripTextModelTrack2", _strip.stripTextModelTrack2());

--- a/app/Joker/JokerWindow.cpp
+++ b/app/Joker/JokerWindow.cpp
@@ -275,6 +275,11 @@ bool JokerWindow::eventFilter(QObject * sender, QEvent *event)
 		{
 			fadeInMediaPanel();
 
+			break;
+
+			// FIXME
+			// do this from QML
+
 			// Check if it is near the video/strip border
 			QMouseEvent * mouseEvent = (QMouseEvent*)event;
 			if(_resizingStrip) {
@@ -326,6 +331,11 @@ bool JokerWindow::eventFilter(QObject * sender, QEvent *event)
 					on_actionOpen_triggered();
 				return true;
 			}
+
+			break;
+			// FIXME
+			// do this from QML
+
 			float stripHeight = this->height() * _settings->stripHeight();
 			if((mouseEvent->pos().y() > (this->height() - stripHeight) - 10)
 			   && (mouseEvent->pos().y() < (this->height() - stripHeight) + 10)) {
@@ -858,41 +868,32 @@ void JokerWindow::onPaint(int width, int height)
 	int stripHeight = (height - y) * stripHeightRatio;
 	int videoHeight = height - y - stripHeight;
 
-	int tcWidth = 200 * this->devicePixelRatio();
+	_videoEngine.decodeVideo();
 
-	if((videoHeight > 0)) {
-		if(_videoEngine.height() > 0) {
-			int videoWidth;
-			if(_doc->forceRatio169())
-				videoWidth = videoHeight * 16 / 9;
-			else
-				videoWidth = videoHeight * _videoEngine.width() / _videoEngine.height();
+//	if((videoHeight > 0)) {
+//		int tcWidth = 200 * this->devicePixelRatio();
+//		if(_videoEngine.height() > 0) {
+//			int videoWidth;
+//			if(_doc->forceRatio169())
+//				videoWidth = videoHeight * 16 / 9;
+//			else
+//				videoWidth = videoHeight * _videoEngine.width() / _videoEngine.height();
 
-			int blackStripHeight = 0; // Height of the upper black strip when video is too large
-			int realVideoHeight = videoHeight;
-			if(videoWidth > width) {
-				videoWidth = width;
-				if(_doc->forceRatio169())
-					realVideoHeight = videoWidth  * 9 / 16;
-				else
-					realVideoHeight = videoWidth  * _videoEngine.height() / _videoEngine.width();
-			}
-			blackStripHeight = (height - stripHeight - realVideoHeight) / 2;
-
-			int videoX = (width - videoWidth) / 2;
-			_videoEngine.decodeVideo();
-
-			// adjust tc size
-			// FIXME this does not work now that QML is used for the timecode labels.
-			if(videoX > tcWidth) {
-				// maximize the timecode if we have more room
-				tcWidth = videoX;
-			} else if( width < 2 * tcWidth) {
-				// make sure the timecode labels do not overlap
-				tcWidth = width / 2;
-			}
-		}
-	}
+//			if(videoWidth > width) {
+//				videoWidth = width;
+//			}
+//			int videoX = (width - videoWidth) / 2;
+//			// adjust tc size
+//			// FIXME this does not work now that QML is used for the timecode labels.
+//			if(videoX > tcWidth) {
+//				// maximize the timecode if we have more room
+//				tcWidth = videoX;
+//			} else if( width < 2 * tcWidth) {
+//				// make sure the timecode labels do not overlap
+//				tcWidth = width / 2;
+//			}
+//		}
+//	}
 
 	QQuickItem *videoLogo = ui->videoStripView->rootObject()->findChild<QQuickItem*>("videoLogo");
 	videoLogo->setVisible((videoHeight > 0) && (_videoEngine.height() <= 0) && _settings->displayLogo());
@@ -958,10 +959,6 @@ void JokerWindow::onPaint(int width, int height)
 
 	PhStripLoop * currentLoop = _strip.doc()->previousLoop(clockTime);
 	setCurrentLoopLabel(currentLoop ? currentLoop->label(): "");
-
-	// placeholder used to position other UI elements
-	QQuickItem *stripItem = ui->videoStripView->rootObject()->findChild<QQuickItem*>("strip");
-	stripItem->setHeight(stripHeight);
 
 	QQuickItem *noSyncLabel = ui->videoStripView->rootObject()->findChild<QQuickItem*>("noSyncLabel");
 	noSyncLabel->setVisible(_lastVideoSyncElapsed.elapsed() > 1000);

--- a/app/Joker/JokerWindow.cpp
+++ b/app/Joker/JokerWindow.cpp
@@ -18,6 +18,7 @@
 #include "PhTools/PhDebug.h"
 #include "PhCommonUI/PhTimeCodeDialog.h"
 #include "PhCommonUI/PhFeedbackDialog.h"
+#include "PhGraphic/PhQmlView.h"
 #include "AboutDialog.h"
 #include "PreferencesDialog.h"
 #include "PeopleDialog.h"
@@ -38,6 +39,11 @@ JokerWindow::JokerWindow(JokerSettings *settings) :
 {
 	// Setting up UI
 	ui->setupUi(this);
+
+	qmlRegisterType<PhQmlView>("Joker", 1, 0, "PhQmlView");
+
+	ui->videoStripView->setResizeMode(QQuickWidget::SizeRootObjectToView);
+	ui->videoStripView->setSource(QUrl("qrc:///Phonations/Joker/main.qml"));
 
 	// Due to translation, Qt might not be able to link automatically the menu
 	ui->actionPreferences->setMenuRole(QAction::PreferencesRole);
@@ -114,7 +120,10 @@ JokerWindow::JokerWindow(JokerSettings *settings) :
 	this->connect(ui->videoStripView, &PhGraphicView::beforePaint, this, &JokerWindow::timeCounter);
 	this->connect(ui->videoStripView, &PhGraphicView::beforePaint, _strip.clock(), &PhClock::tick);
 
-	this->connect(ui->videoStripView, &PhGraphicView::paint, this, &JokerWindow::onPaint);
+	PhQmlView *OpenGLView = ui->videoStripView->rootObject()->findChild<PhQmlView*>("PhQmlView");
+	if (OpenGLView) {
+		this->connect(OpenGLView, &PhQmlView::paint, this, &JokerWindow::onPaint, Qt::DirectConnection);
+	}
 
 	_videoLogo.setFilename(QCoreApplication::applicationDirPath() + PATH_TO_RESSOURCES + "/phonations.png");
 }

--- a/app/Joker/JokerWindow.cpp
+++ b/app/Joker/JokerWindow.cpp
@@ -926,7 +926,7 @@ void JokerWindow::onPaint(int width, int height)
 	setStripInfo(stripInfoText);
 
 	QQuickItem *infosItem = ui->videoStripView->rootObject()->findChild<QQuickItem*>("infos");
-	infosItem->setVisible(true);//_settings->displayInfo());
+	infosItem->setVisible(_settings->displayInfo());
 
 	PhStripText *nextText = NULL;
 	if(_settings->displayNextTC()) {

--- a/app/Joker/JokerWindow.cpp
+++ b/app/Joker/JokerWindow.cpp
@@ -53,7 +53,7 @@ JokerWindow::JokerWindow(JokerSettings *settings) :
 	ui->videoStripView->engine()->rootContext()->setContextProperty("nextPeopleModel", QVariant::fromValue(_nextPeoples));
 	ui->videoStripView->engine()->rootContext()->setContextProperty("verticalTimePerPixel", _settings->verticalTimePerPixel());
 	ui->videoStripView->engine()->rootContext()->setContextProperty("clockTime", _strip.clock()->time() + _settings->screenDelay());
-
+	ui->videoStripView->engine()->rootContext()->setContextProperty("horizontalTimePerPixel", _settings->horizontalTimePerPixel());
 
 	ui->videoStripView->setResizeMode(QQuickWidget::SizeRootObjectToView);
 	ui->videoStripView->setSource(QUrl("qrc:///Phonations/Joker/main.qml"));
@@ -922,6 +922,16 @@ void JokerWindow::onPaint(int width, int height)
 	// TODO the view could be refreshed more intelligently by defining a true model and define change signals
 	ui->videoStripView->engine()->rootContext()->setContextProperty("nextPeopleModel", QVariant::fromValue(_nextPeoples));
 
+
+	QList<QObject*> stripTexts;
+	foreach(PhStripText *text, _strip.stripTexts()) {
+		stripTexts.append(text);
+	}
+
+	// refresh the view
+	// TODO the view could be refreshed more intelligently by defining a true model and define change signals
+	ui->videoStripView->engine()->rootContext()->setContextProperty("stripTextModel", QVariant::fromValue(stripTexts));
+
 	// prepare the string list that is used to display the infos
 	_infoList.clear();
 	_infoList.append(QString("refresh: %1x%2, %3 / %4")
@@ -973,8 +983,8 @@ void JokerWindow::onPaint(int width, int height)
 	setCurrentLoopLabel(currentLoop ? currentLoop->label(): "");
 
 	// placeholder used to position other UI elements
-	QQuickItem *stripPlaceholder = ui->videoStripView->rootObject()->findChild<QQuickItem*>("stripPlaceholder");
-	stripPlaceholder->setHeight(stripHeight);
+	QQuickItem *stripItem = ui->videoStripView->rootObject()->findChild<QQuickItem*>("strip");
+	stripItem->setHeight(stripHeight);
 
 	QQuickItem *noSyncLabel = ui->videoStripView->rootObject()->findChild<QQuickItem*>("noSyncLabel");
 	noSyncLabel->setVisible(_lastVideoSyncElapsed.elapsed() > 1000);

--- a/app/Joker/JokerWindow.cpp
+++ b/app/Joker/JokerWindow.cpp
@@ -65,6 +65,7 @@ JokerWindow::JokerWindow(JokerSettings *settings) :
 	ui->videoStripView->engine()->rootContext()->setContextProperty("displayRuler", _settings->displayRuler());
 	ui->videoStripView->engine()->rootContext()->setContextProperty("videoLogoUrl", QUrl::fromLocalFile(QCoreApplication::applicationDirPath() + PATH_TO_RESSOURCES + "/phonations.png"));
 	ui->videoStripView->engine()->rootContext()->setContextProperty("stripBackgroundUrl", QUrl::fromLocalFile(_settings->backgroundImageLight()));
+	ui->videoStripView->engine()->rootContext()->setContextProperty("videoSource", &_videoSurface);
 
 	ui->videoStripView->setResizeMode(QQuickWidget::SizeRootObjectToView);
 	ui->videoStripView->setSource(QUrl("qrc:///Phonations/Joker/main.qml"));
@@ -74,6 +75,8 @@ JokerWindow::JokerWindow(JokerSettings *settings) :
 	ui->actionAbout->setMenuRole(QAction::AboutRole);
 
 	connect(ui->actionFullscreen, SIGNAL(triggered()), this, SLOT(toggleFullScreen()));
+
+	connect(&_videoEngine, &PhVideoEngine::newVideoContentProduced, &_videoSurface, &PhVideoSurface::onNewVideoContentReceived);
 
 	ui->videoStripView->setGraphicSettings(_settings);
 
@@ -877,7 +880,7 @@ void JokerWindow::onPaint(int width, int height)
 			blackStripHeight = (height - stripHeight - realVideoHeight) / 2;
 
 			int videoX = (width - videoWidth) / 2;
-			_videoEngine.drawVideo(videoX, y + blackStripHeight, videoWidth, realVideoHeight);
+			_videoEngine.decodeVideo();
 
 			// adjust tc size
 			// FIXME this does not work now that QML is used for the timecode labels.

--- a/app/Joker/JokerWindow.cpp
+++ b/app/Joker/JokerWindow.cpp
@@ -63,6 +63,8 @@ JokerWindow::JokerWindow(JokerSettings *settings) :
 	ui->videoStripView->engine()->rootContext()->setContextProperty("displayCuts", _settings->displayCuts());
 	ui->videoStripView->engine()->rootContext()->setContextProperty("invertColor", _settings->invertColor());
 	ui->videoStripView->engine()->rootContext()->setContextProperty("displayRuler", _settings->displayRuler());
+	ui->videoStripView->engine()->rootContext()->setContextProperty("videoLogoUrl", QUrl::fromLocalFile(QCoreApplication::applicationDirPath() + PATH_TO_RESSOURCES + "/phonations.png"));
+	ui->videoStripView->engine()->rootContext()->setContextProperty("stripBackgroundUrl", QUrl::fromLocalFile(_settings->backgroundImageLight()));
 
 	ui->videoStripView->setResizeMode(QQuickWidget::SizeRootObjectToView);
 	ui->videoStripView->setSource(QUrl("qrc:///Phonations/Joker/main.qml"));
@@ -144,10 +146,6 @@ JokerWindow::JokerWindow(JokerSettings *settings) :
 
 	PhQmlView *OpenGLView = ui->videoStripView->rootObject()->findChild<PhQmlView*>("PhQmlView");
 	this->connect(OpenGLView, &PhQmlView::paint, this, &JokerWindow::onPaint, Qt::DirectConnection);
-
-	_videoLogo.setFilename(QCoreApplication::applicationDirPath() + PATH_TO_RESSOURCES + "/phonations.png");
-	QQuickItem *videoLogo = ui->videoStripView->rootObject()->findChild<QQuickItem*>("videoLogo");
-	videoLogo->setProperty("source", QUrl::fromLocalFile(QCoreApplication::applicationDirPath() + PATH_TO_RESSOURCES + "/phonations.png"));
 }
 
 JokerWindow::~JokerWindow()

--- a/app/Joker/JokerWindow.cpp
+++ b/app/Joker/JokerWindow.cpp
@@ -50,7 +50,7 @@ JokerWindow::JokerWindow(JokerSettings *settings) :
 	ui->videoStripView->engine()->rootContext()->setContextProperty("jokerWindow", this);
 	ui->videoStripView->engine()->rootContext()->setContextProperty("selectedPeopleModel", QVariant::fromValue(_selectedPeopleList));
 	ui->videoStripView->engine()->rootContext()->setContextProperty("infoModel", QVariant::fromValue(_infoList));
-	ui->videoStripView->engine()->rootContext()->setContextProperty("nextPeopleModel", QVariant::fromValue(_nextPeoples));
+	ui->videoStripView->engine()->rootContext()->setContextProperty("nextPeopleModel", _strip.nextPeopleModel());
 	ui->videoStripView->engine()->rootContext()->setContextProperty("verticalTimePerPixel", _settings->verticalTimePerPixel());
 	ui->videoStripView->engine()->rootContext()->setContextProperty("clockTime", _strip.clock()->time() + _settings->screenDelay());
 	ui->videoStripView->engine()->rootContext()->setContextProperty("horizontalTimePerPixel", _settings->horizontalTimePerPixel());
@@ -908,20 +908,6 @@ void JokerWindow::onPaint(int width, int height)
 	_strip.draw(0, y + videoHeight, width, stripHeight, tcOffset, selectedPeoples);
 
 	ui->videoStripView->engine()->rootContext()->setContextProperty("clockTime", _strip.clock()->time() + _settings->screenDelay());
-
-	// Note: _selectedPeopleList is needed because QVariant does not know how to handle a QList<PhPeople*>
-	// we convert it to QList<QObject*>
-	ui->videoStripView->engine()->rootContext()->setContextProperty("nextPeopleModel", NULL);
-	qDeleteAll(_nextPeoples);
-	_nextPeoples.clear();
-	foreach(PhNextPeople *nextPeople, _strip.nextPeoples()) {
-		_nextPeoples.append(nextPeople);
-	}
-
-	// refresh the view
-	// TODO the view could be refreshed more intelligently by defining a true model and define change signals
-	ui->videoStripView->engine()->rootContext()->setContextProperty("nextPeopleModel", QVariant::fromValue(_nextPeoples));
-
 
 	QList<QObject*> stripTexts;
 	foreach(PhStripText *text, _strip.stripTexts()) {

--- a/app/Joker/JokerWindow.cpp
+++ b/app/Joker/JokerWindow.cpp
@@ -902,8 +902,37 @@ void JokerWindow::onPaint(int width, int height)
 		tcOffset = tcLabel->height();
 
 	_strip.draw(0, y + videoHeight, width, stripHeight, tcOffset, selectedPeoples);
+
+	QStringList infos;
+	infos.append(QString("refresh: %1x%2, %3 / %4")
+			.arg(ui->videoStripView->width())
+			.arg(ui->videoStripView->height())
+			.arg(ui->videoStripView->maxRefreshRate())
+			.arg(ui->videoStripView->refreshRate()));
+	infos.append(QString("Update : %1 %2").arg(ui->videoStripView->maxUpdateDuration()).arg(ui->videoStripView->lastUpdateDuration()));
+	infos.append(QString("drop: %1 %2").arg(ui->videoStripView->dropDetected()).arg(ui->videoStripView->secondsSinceLastDrop()));
+
+	#warning /// @todo measure fps with a custom QML element
+	// The actual painting duration should be measured using a custom QML element.
+	// See: http://developer.nokia.com/community/wiki/QML_Performance_Meter
+	// (anyway, the QML profiler will provide much more details to the developer.)
+	infos.append(QString("draw: N/A"));
+
 	foreach(QString info, _strip.infos()) {
-		ui->videoStripView->addInfo(info);
+		infos.append(info);
+	}
+
+	if(_settings->displayInfo()) {
+		_infoFont.setFontFile(_settings->infoFontFile());
+		int y2 = 0;
+		foreach(QString info, infos) {
+			PhGraphicText gInfo(&_infoFont, info, 0, y2);
+			gInfo.setSize(_infoFont.getNominalWidth(info) / 2, 50);
+			gInfo.setZ(10);
+			gInfo.setColor(Qt::red);
+			gInfo.draw();
+			y2 += gInfo.height();
+		}
 	}
 
 	PhStripText *nextText = NULL;

--- a/app/Joker/JokerWindow.cpp
+++ b/app/Joker/JokerWindow.cpp
@@ -50,7 +50,6 @@ JokerWindow::JokerWindow(JokerSettings *settings) :
 	ui->videoStripView->engine()->rootContext()->setContextProperty("doc", _doc);
 	ui->videoStripView->engine()->rootContext()->setContextProperty("jokerWindow", this);
 	ui->videoStripView->engine()->rootContext()->setContextProperty("selectedPeopleModel", QVariant::fromValue(_selectedPeopleList));
-	ui->videoStripView->engine()->rootContext()->setContextProperty("infoModel", QVariant::fromValue(_infoList));
 	ui->videoStripView->engine()->rootContext()->setContextProperty("nextPeopleModel", _strip.nextPeopleModel());
 	ui->videoStripView->engine()->rootContext()->setContextProperty("stripTextModelTrack0", _strip.stripTextModelTrack0());
 	ui->videoStripView->engine()->rootContext()->setContextProperty("stripTextModelTrack1", _strip.stripTextModelTrack1());
@@ -913,26 +912,27 @@ void JokerWindow::onPaint(int width, int height)
 	_strip.draw(0, y + videoHeight, width, stripHeight, tcOffset, selectedPeoples);
 
 	// prepare the string list that is used to display the infos
-	_infoList.clear();
-	_infoList.append(QString("refresh: %1x%2, %3 / %4")
-			.arg(ui->videoStripView->width())
-			.arg(ui->videoStripView->height())
-			.arg(ui->videoStripView->maxRefreshRate())
-			.arg(ui->videoStripView->refreshRate()));
-	_infoList.append(QString("Update : %1 %2").arg(ui->videoStripView->maxUpdateDuration()).arg(ui->videoStripView->lastUpdateDuration()));
-	_infoList.append(QString("drop: %1 %2").arg(ui->videoStripView->dropDetected()).arg(ui->videoStripView->secondsSinceLastDrop()));
+	setRefreshInfo(QString("refresh: %1x%2, %3 / %4")
+				   .arg(ui->videoStripView->width())
+				   .arg(ui->videoStripView->height())
+				   .arg(ui->videoStripView->maxRefreshRate())
+				   .arg(ui->videoStripView->refreshRate()));
+	setUpdateInfo(QString("Update : %1 %2").arg(ui->videoStripView->maxUpdateDuration())
+										.arg(ui->videoStripView->lastUpdateDuration()));
+	setDropInfo(QString("drop: %1 %2").arg(ui->videoStripView->dropDetected()).arg(ui->videoStripView->secondsSinceLastDrop()));
 	#warning /// @todo measure fps with a custom QML element
 	// The actual painting duration should be measured using a custom QML element.
 	// See: http://developer.nokia.com/community/wiki/QML_Performance_Meter
 	// (anyway, the QML profiler will provide much more details to the developer.)
-	_infoList.append(QString("draw: N/A"));
-	foreach(QString info, _strip.infos()) {
-		_infoList.append(info);
-	}
 
-	ui->videoStripView->engine()->rootContext()->setContextProperty("infoModel", QVariant::fromValue(_infoList));
-	QQuickItem *infoList = ui->videoStripView->rootObject()->findChild<QQuickItem*>("infoList");
-	infoList->setVisible(_settings->displayInfo());
+	QString stripInfoText;
+	foreach(QString info, _strip.infos()) {
+		stripInfoText.append(info);
+	}
+	setStripInfo(stripInfoText);
+
+	QQuickItem *infosItem = ui->videoStripView->rootObject()->findChild<QQuickItem*>("infos");
+	infosItem->setVisible(true);//_settings->displayInfo());
 
 	PhStripText *nextText = NULL;
 	if(_settings->displayNextTC()) {
@@ -1025,5 +1025,37 @@ void JokerWindow::setStripTime(PhTime time)
 	if (time != _stripTime) {
 		_stripTime = time;
 		emit stripTimeChanged();
+	}
+}
+
+void JokerWindow::setRefreshInfo(QString text)
+{
+	if (text != _refreshInfo) {
+		_refreshInfo = text;
+		emit refreshInfoChanged();
+	}
+}
+
+void JokerWindow::setUpdateInfo(QString text)
+{
+	if (text != _updateInfo) {
+		_updateInfo = text;
+		emit updateInfoChanged();
+	}
+}
+
+void JokerWindow::setDropInfo(QString text)
+{
+	if (text != _dropInfo) {
+		_dropInfo = text;
+		emit dropInfoChanged();
+	}
+}
+
+void JokerWindow::setStripInfo(QString text)
+{
+	if (text != _stripInfo) {
+		_stripInfo = text;
+		emit stripInfoChanged();
 	}
 }

--- a/app/Joker/JokerWindow.cpp
+++ b/app/Joker/JokerWindow.cpp
@@ -49,6 +49,7 @@ JokerWindow::JokerWindow(JokerSettings *settings) :
 	ui->videoStripView->engine()->rootContext()->setContextProperty("doc", _doc);
 	ui->videoStripView->engine()->rootContext()->setContextProperty("jokerWindow", this);
 	ui->videoStripView->engine()->rootContext()->setContextProperty("selectedPeopleModel", QVariant::fromValue(_selectedPeopleList));
+	ui->videoStripView->engine()->rootContext()->setContextProperty("infoModel", QVariant::fromValue(_infoList));
 
 	ui->videoStripView->setResizeMode(QQuickWidget::SizeRootObjectToView);
 	ui->videoStripView->setSource(QUrl("qrc:///Phonations/Joker/main.qml"));
@@ -903,37 +904,27 @@ void JokerWindow::onPaint(int width, int height)
 
 	_strip.draw(0, y + videoHeight, width, stripHeight, tcOffset, selectedPeoples);
 
-	QStringList infos;
-	infos.append(QString("refresh: %1x%2, %3 / %4")
+	// prepare the string list that is used to display the infos
+	_infoList.clear();
+	_infoList.append(QString("refresh: %1x%2, %3 / %4")
 			.arg(ui->videoStripView->width())
 			.arg(ui->videoStripView->height())
 			.arg(ui->videoStripView->maxRefreshRate())
 			.arg(ui->videoStripView->refreshRate()));
-	infos.append(QString("Update : %1 %2").arg(ui->videoStripView->maxUpdateDuration()).arg(ui->videoStripView->lastUpdateDuration()));
-	infos.append(QString("drop: %1 %2").arg(ui->videoStripView->dropDetected()).arg(ui->videoStripView->secondsSinceLastDrop()));
-
+	_infoList.append(QString("Update : %1 %2").arg(ui->videoStripView->maxUpdateDuration()).arg(ui->videoStripView->lastUpdateDuration()));
+	_infoList.append(QString("drop: %1 %2").arg(ui->videoStripView->dropDetected()).arg(ui->videoStripView->secondsSinceLastDrop()));
 	#warning /// @todo measure fps with a custom QML element
 	// The actual painting duration should be measured using a custom QML element.
 	// See: http://developer.nokia.com/community/wiki/QML_Performance_Meter
 	// (anyway, the QML profiler will provide much more details to the developer.)
-	infos.append(QString("draw: N/A"));
-
+	_infoList.append(QString("draw: N/A"));
 	foreach(QString info, _strip.infos()) {
-		infos.append(info);
+		_infoList.append(info);
 	}
 
-	if(_settings->displayInfo()) {
-		_infoFont.setFontFile(_settings->infoFontFile());
-		int y2 = 0;
-		foreach(QString info, infos) {
-			PhGraphicText gInfo(&_infoFont, info, 0, y2);
-			gInfo.setSize(_infoFont.getNominalWidth(info) / 2, 50);
-			gInfo.setZ(10);
-			gInfo.setColor(Qt::red);
-			gInfo.draw();
-			y2 += gInfo.height();
-		}
-	}
+	ui->videoStripView->engine()->rootContext()->setContextProperty("infoModel", QVariant::fromValue(_infoList));
+	QQuickItem *infoList = ui->videoStripView->rootObject()->findChild<QQuickItem*>("infoList");
+	infoList->setVisible(_settings->displayInfo());
 
 	PhStripText *nextText = NULL;
 	if(_settings->displayNextTC()) {

--- a/app/Joker/JokerWindow.cpp
+++ b/app/Joker/JokerWindow.cpp
@@ -901,40 +901,38 @@ void JokerWindow::onPaint(int width, int height)
 	tcLabel->setVisible(_settings->displayTC());
 	tcLabel->setProperty("text", PhTimeCode::stringFromTime(clockTime, _videoEngine.timeCodeType()));
 
+	PhStripText *nextText = NULL;
 	if(_settings->displayNextTC()) {
-		PhStripText *nextText = NULL;
-		PhGraphicText nextTCText(_strip.getHUDFont());
-		nextTCText.setColor(Qt::red);
-
-		nextTCText.setRect(width - tcWidth, y, tcWidth, tcHeight);
-		y += tcHeight;
-
 		/// The next time code will be the next element of the people from the list.
 		if(selectedPeoples.count()) {
 			nextText = _strip.doc()->nextText(selectedPeoples, clockTime);
 			if(nextText == NULL)
 				nextText = _strip.doc()->nextText(selectedPeoples, 0);
-
-			int peopleHeight = height / 30;
-			PhGraphicText peopleNameText(_strip.getHUDFont());
-			peopleNameText.setColor(QColor(128, 128, 128));
-			foreach(PhPeople* people, selectedPeoples) {
-				int peopleNameWidth = people->name().length() * peopleHeight / 2;
-				peopleNameText.setRect(10, y, peopleNameWidth, peopleHeight);
-				peopleNameText.setContent(people->name());
-				peopleNameText.draw();
-				y += peopleHeight;
-			}
 		}
 		else {
 			nextText = _strip.doc()->nextText(clockTime);
 			if(nextText == NULL)
 				nextText = _strip.doc()->nextText(0);
 		}
+	}
 
-		if(nextText != NULL) {
-			nextTCText.setContent(PhTimeCode::stringFromTime(nextText->timeIn(), _videoEngine.timeCodeType()));
-			nextTCText.draw();
+	QQuickItem *nextTcLabel = ui->videoStripView->rootObject()->findChild<QQuickItem*>("nextTcLabel");
+	nextTcLabel->setVisible(_settings->displayNextTC() && nextText != NULL);
+	if (nextText != NULL) {
+		nextTcLabel->setProperty("text", PhTimeCode::stringFromTime(nextText->timeIn(), _videoEngine.timeCodeType()));
+	}
+	y += nextTcLabel->height()*nextTcLabel->isVisible();
+
+	if(_settings->displayNextTC() && selectedPeoples.count()) {
+		int peopleHeight = height / 30;
+		PhGraphicText peopleNameText(_strip.getHUDFont());
+		peopleNameText.setColor(QColor(128, 128, 128));
+		foreach(PhPeople* people, selectedPeoples) {
+			int peopleNameWidth = people->name().length() * peopleHeight / 2;
+			peopleNameText.setRect(10, y, peopleNameWidth, peopleHeight);
+			peopleNameText.setContent(people->name());
+			peopleNameText.draw();
+			y += peopleHeight;
 		}
 	}
 

--- a/app/Joker/JokerWindow.cpp
+++ b/app/Joker/JokerWindow.cpp
@@ -952,15 +952,10 @@ void JokerWindow::onPaint(int width, int height)
 		gCurrentLoop.draw();
 	}
 
-	if(_lastVideoSyncElapsed.elapsed() > 1000) {
-		PhGraphicText errorText(_strip.getHUDFont(), tr("No video sync"));
-		errorText.setRect(width / 2 - 100, height / 2 - 25, 200, 50);
-		int red = (_lastVideoSyncElapsed.elapsed() - 1000) / 4;
-		if (red > 255)
-			red = 255;
-		errorText.setColor(QColor(red, 0, 0));
-		errorText.draw();
-	}
+	QQuickItem *noSyncLabel = ui->videoStripView->rootObject()->findChild<QQuickItem*>("noSyncLabel");
+	noSyncLabel->setVisible(_lastVideoSyncElapsed.elapsed() > 1000);
+	double opacity = (_lastVideoSyncElapsed.elapsed() - 1000.0d) / 1000.0d;
+	noSyncLabel->setOpacity(opacity <= 0 ? 0 : opacity >= 1 ? 1 : opacity);
 }
 
 void JokerWindow::onVideoSync()

--- a/app/Joker/JokerWindow.cpp
+++ b/app/Joker/JokerWindow.cpp
@@ -51,6 +51,7 @@ JokerWindow::JokerWindow(JokerSettings *settings) :
 	ui->videoStripView->engine()->rootContext()->setContextProperty("jokerWindow", this);
 	ui->videoStripView->engine()->rootContext()->setContextProperty("selectedPeopleModel", &_selectedPeopleModel);
 	ui->videoStripView->engine()->rootContext()->setContextProperty("nextPeopleModel", _strip.nextPeopleModel());
+	ui->videoStripView->engine()->rootContext()->setContextProperty("cutModel", _strip.cutModel());
 	ui->videoStripView->engine()->rootContext()->setContextProperty("stripTextModelTrack0", _strip.stripTextModelTrack0());
 	ui->videoStripView->engine()->rootContext()->setContextProperty("stripTextModelTrack1", _strip.stripTextModelTrack1());
 	ui->videoStripView->engine()->rootContext()->setContextProperty("stripTextModelTrack2", _strip.stripTextModelTrack2());
@@ -59,6 +60,9 @@ JokerWindow::JokerWindow(JokerSettings *settings) :
 	ui->videoStripView->engine()->rootContext()->setContextProperty("horizontalTimePerPixel", _settings->horizontalTimePerPixel());
 	ui->videoStripView->engine()->rootContext()->setContextProperty("textFontUrl", QUrl::fromLocalFile(_settings->textFontFile()));
 	ui->videoStripView->engine()->rootContext()->setContextProperty("textBoldness", _settings->textBoldness());
+	ui->videoStripView->engine()->rootContext()->setContextProperty("cutWidth", _settings->cutWidth());
+	ui->videoStripView->engine()->rootContext()->setContextProperty("displayCuts", _settings->displayCuts());
+	ui->videoStripView->engine()->rootContext()->setContextProperty("invertColor", _settings->invertColor());
 
 	ui->videoStripView->setResizeMode(QQuickWidget::SizeRootObjectToView);
 	ui->videoStripView->setSource(QUrl("qrc:///Phonations/Joker/main.qml"));

--- a/app/Joker/JokerWindow.h
+++ b/app/Joker/JokerWindow.h
@@ -44,6 +44,10 @@ class JokerWindow : public PhDocumentWindow
 	Q_OBJECT
 	Q_PROPERTY(QString currentLoopLabel READ currentLoopLabel WRITE setCurrentLoopLabel NOTIFY currentLoopLabelChanged)
 	Q_PROPERTY(PhTime stripTime READ stripTime WRITE setStripTime NOTIFY stripTimeChanged)
+	Q_PROPERTY(QString refreshInfo READ refreshInfo WRITE setRefreshInfo NOTIFY refreshInfoChanged)
+	Q_PROPERTY(QString updateInfo READ updateInfo WRITE setUpdateInfo NOTIFY updateInfoChanged)
+	Q_PROPERTY(QString dropInfo READ dropInfo WRITE setDropInfo NOTIFY dropInfoChanged)
+	Q_PROPERTY(QString stripInfo READ stripInfo WRITE setStripInfo NOTIFY stripInfoChanged)
 
 public:
 	///
@@ -88,6 +92,26 @@ public:
 	 * @param A PhTime
 	 */
 	void setStripTime(PhTime time);
+
+	QString refreshInfo() {
+		return _refreshInfo;
+	}
+	void setRefreshInfo(QString text);
+
+	QString updateInfo() {
+		return _updateInfo;
+	}
+	void setUpdateInfo(QString text);
+
+	QString dropInfo() {
+		return _dropInfo;
+	}
+	void setDropInfo(QString text);
+
+	QString stripInfo() {
+		return _stripInfo;
+	}
+	void setStripInfo(QString text);
 
 public slots:
 	///
@@ -270,6 +294,10 @@ private slots:
 signals:
 	void currentLoopLabelChanged();
 	void stripTimeChanged();
+	void refreshInfoChanged();
+	void updateInfoChanged();
+	void dropInfoChanged();
+	void stripInfoChanged();
 
 private:
 	Ui::JokerWindow *ui;
@@ -300,7 +328,11 @@ private:
 	PhTime _stripTime;
 	QString _currentLoopLabel;
 	QList<QObject*> _selectedPeopleList;
-	QStringList _infoList;
+
+	QString _refreshInfo;
+	QString _updateInfo;
+	QString _dropInfo;
+	QString _stripInfo;
 
 	PhFont _infoFont;
 };

--- a/app/Joker/JokerWindow.h
+++ b/app/Joker/JokerWindow.h
@@ -14,6 +14,7 @@
 #include "PhCommonUI/PhFloatingMediaPanel.h"
 #include "PhCommonUI/PhDocumentWindow.h"
 #include <PhVideo/PhVideoEngine.h>
+#include <PhVideo/PhVideoSurface.h>
 #include <PhGraphicStrip/PhGraphicStrip.h>
 #include "PhSync/PhSynchronizer.h"
 #include "PhSony/PhSonySlaveController.h"
@@ -333,6 +334,8 @@ private:
 	QString _stripInfo;
 
 	PhFont _infoFont;
+
+	PhVideoSurface _videoSurface;
 };
 
 #endif // MAINWINDOW_H

--- a/app/Joker/JokerWindow.h
+++ b/app/Joker/JokerWindow.h
@@ -290,7 +290,6 @@ private:
 	PhFont _infoFont;
 
 	QList<QObject*> _nextPeoples;
-	QList<QObject*> _stripTexts;
 };
 
 #endif // MAINWINDOW_H

--- a/app/Joker/JokerWindow.h
+++ b/app/Joker/JokerWindow.h
@@ -288,6 +288,8 @@ private:
 	QStringList _infoList;
 
 	PhFont _infoFont;
+
+	QList<QObject*> _nextPeoples;
 };
 
 #endif // MAINWINDOW_H

--- a/app/Joker/JokerWindow.h
+++ b/app/Joker/JokerWindow.h
@@ -42,6 +42,7 @@ class JokerWindow;
 class JokerWindow : public PhDocumentWindow
 {
 	Q_OBJECT
+	Q_PROPERTY(QString currentLoopLabel READ currentLoopLabel WRITE setCurrentLoopLabel NOTIFY currentLoopLabelChanged)
 
 public:
 	///
@@ -62,6 +63,18 @@ public:
 	/// @return True if the videoFile opened well, false otherwise.
 	///
 	bool openVideoFile(QString videoFile);
+
+	/**
+	 * @brief The current loop label
+	 * @return A string
+	 */
+	QString currentLoopLabel();
+
+	/**
+	 * @brief Sets the current loop label
+	 * @param A string
+	 */
+	void setCurrentLoopLabel(QString label);
 
 public slots:
 	///
@@ -241,6 +254,9 @@ private slots:
 
 	void on_actionSet_space_between_two_ruler_graduation_triggered();
 
+signals:
+	void currentLoopLabelChanged();
+
 private:
 	Ui::JokerWindow *ui;
 	JokerSettings *_settings;
@@ -266,6 +282,8 @@ private:
 	PhGraphicImage _videoLogo;
 
 	QTime _lastVideoSyncElapsed;
+
+	QString _currentLoopLabel;
 };
 
 #endif // MAINWINDOW_H

--- a/app/Joker/JokerWindow.h
+++ b/app/Joker/JokerWindow.h
@@ -43,6 +43,7 @@ class JokerWindow : public PhDocumentWindow
 {
 	Q_OBJECT
 	Q_PROPERTY(QString currentLoopLabel READ currentLoopLabel WRITE setCurrentLoopLabel NOTIFY currentLoopLabelChanged)
+	Q_PROPERTY(PhTime stripTime READ stripTime WRITE setStripTime NOTIFY stripTimeChanged)
 
 public:
 	///
@@ -75,6 +76,18 @@ public:
 	 * @param A string
 	 */
 	void setCurrentLoopLabel(QString label);
+
+	/**
+	 * @brief The strip time (includes delay)
+	 * @return A PhTime
+	 */
+	PhTime stripTime();
+
+	/**
+	 * @brief Sets the strip time
+	 * @param A PhTime
+	 */
+	void setStripTime(PhTime time);
 
 public slots:
 	///
@@ -256,6 +269,7 @@ private slots:
 
 signals:
 	void currentLoopLabelChanged();
+	void stripTimeChanged();
 
 private:
 	Ui::JokerWindow *ui;
@@ -283,6 +297,7 @@ private:
 
 	QTime _lastVideoSyncElapsed;
 
+	PhTime _stripTime;
 	QString _currentLoopLabel;
 	QList<QObject*> _selectedPeopleList;
 	QStringList _infoList;

--- a/app/Joker/JokerWindow.h
+++ b/app/Joker/JokerWindow.h
@@ -288,8 +288,6 @@ private:
 	QStringList _infoList;
 
 	PhFont _infoFont;
-
-	QList<QObject*> _nextPeoples;
 };
 
 #endif // MAINWINDOW_H

--- a/app/Joker/JokerWindow.h
+++ b/app/Joker/JokerWindow.h
@@ -290,6 +290,7 @@ private:
 	PhFont _infoFont;
 
 	QList<QObject*> _nextPeoples;
+	QList<QObject*> _stripTexts;
 };
 
 #endif // MAINWINDOW_H

--- a/app/Joker/JokerWindow.h
+++ b/app/Joker/JokerWindow.h
@@ -285,6 +285,8 @@ private:
 
 	QString _currentLoopLabel;
 	QList<QObject*> _selectedPeopleList;
+
+	PhFont _infoFont;
 };
 
 #endif // MAINWINDOW_H

--- a/app/Joker/JokerWindow.h
+++ b/app/Joker/JokerWindow.h
@@ -327,7 +327,7 @@ private:
 
 	PhTime _stripTime;
 	QString _currentLoopLabel;
-	QList<QObject*> _selectedPeopleList;
+	QStringListModel _selectedPeopleModel;
 
 	QString _refreshInfo;
 	QString _updateInfo;

--- a/app/Joker/JokerWindow.h
+++ b/app/Joker/JokerWindow.h
@@ -284,6 +284,7 @@ private:
 	QTime _lastVideoSyncElapsed;
 
 	QString _currentLoopLabel;
+	QList<QObject*> _selectedPeopleList;
 };
 
 #endif // MAINWINDOW_H

--- a/app/Joker/JokerWindow.h
+++ b/app/Joker/JokerWindow.h
@@ -321,8 +321,6 @@ private:
 	bool _resizingStrip;
 	int _numberOfDraw;
 
-	PhGraphicImage _videoLogo;
-
 	QTime _lastVideoSyncElapsed;
 
 	PhTime _stripTime;

--- a/app/Joker/JokerWindow.h
+++ b/app/Joker/JokerWindow.h
@@ -285,6 +285,7 @@ private:
 
 	QString _currentLoopLabel;
 	QList<QObject*> _selectedPeopleList;
+	QStringList _infoList;
 
 	PhFont _infoFont;
 };

--- a/app/Joker/JokerWindow.h
+++ b/app/Joker/JokerWindow.h
@@ -10,6 +10,7 @@
 #include <QMessageBox>
 #include <QPropertyAnimation>
 #include <QTimer>
+#include <QQmlContext>
 
 #include "PhCommonUI/PhFloatingMediaPanel.h"
 #include "PhCommonUI/PhDocumentWindow.h"
@@ -20,7 +21,7 @@
 #include "PhSony/PhSonySlaveController.h"
 #include "PhLtc/PhLtcReader.h"
 #include "PhMidi/PhMidiTimeCodeReader.h"
-
+#include "PhGraphic/PhGraphicView.h"
 #include "PropertyDialog.h"
 #include "JokerSettings.h"
 #include "RulerSpaceDialog.h"
@@ -280,7 +281,8 @@ private slots:
 
 	void on_actionHide_the_rythmo_triggered(bool checked);
 
-	void onPaint(int width, int height);
+	//void onPaint(int width, int height);
+	void onPaint(PhTimeScale frequency);
 
 	void onVideoSync();
 
@@ -291,6 +293,8 @@ private slots:
 	void on_actionDisplay_the_cuts_toggled(bool checked);
 
 	void on_actionSet_space_between_two_ruler_graduation_triggered();
+
+	void qmlStatusChanged(QQuickView::Status status);
 
 signals:
 	void currentLoopLabelChanged();
@@ -336,6 +340,10 @@ private:
 	PhFont _infoFont;
 
 	PhVideoSurface _videoSurface;
+
+	QQmlContext *_context;
+
+	PhGraphicView *_view = new PhGraphicView();
 };
 
 #endif // MAINWINDOW_H

--- a/app/Joker/JokerWindow.ui
+++ b/app/Joker/JokerWindow.ui
@@ -14,7 +14,7 @@
    <string>Joker</string>
   </property>
   <widget class="QWidget" name="centralwidget">
-   <layout class="QVBoxLayout" name="verticalLayout" stretch="1">
+   <layout class="QVBoxLayout" name="verticalLayout" stretch="">
     <property name="spacing">
      <number>0</number>
     </property>
@@ -30,9 +30,6 @@
     <property name="bottomMargin">
      <number>0</number>
     </property>
-    <item>
-     <widget class="PhGraphicView" name="videoStripView" native="true"/>
-    </item>
    </layout>
   </widget>
   <widget class="QMenuBar" name="menubar">
@@ -41,7 +38,7 @@
      <x>0</x>
      <y>0</y>
      <width>820</width>
-     <height>22</height>
+     <height>21</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -459,14 +456,6 @@
    </property>
   </action>
  </widget>
- <customwidgets>
-  <customwidget>
-   <class>PhGraphicView</class>
-   <extends>QWidget</extends>
-   <header>PhGraphic/PhGraphicView.h</header>
-   <container>1</container>
-  </customwidget>
- </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/app/Joker/LeftColumn.qml
+++ b/app/Joker/LeftColumn.qml
@@ -1,0 +1,68 @@
+import QtQuick 2.0
+
+Item {
+    id: leftColumn
+    width: 300
+    height: 500
+
+    Text {
+        id: tcLabel
+        objectName: "tcLabel"
+        color: "#00ff00"
+        text: "#"
+        wrapMode: Text.WordWrap
+        font.pointSize: 29
+        anchors.top: parent.top
+        anchors.left: parent.left
+    }
+
+    Item {
+        anchors.top: tcLabel.bottom
+        anchors.left: parent.left
+        anchors.leftMargin: 10
+
+        ListView {
+            objectName: "infoList"
+            height: childrenRect.height
+
+            model: infoModel
+            delegate: Text {
+                text: modelData
+                color: "red"
+                font.pointSize: tcLabel.font.pointSize
+                lineHeight: 0.75
+                wrapMode: Text.WordWrap
+            }
+        }
+    }
+
+    ListView {
+        objectName: "selectedPeopleList"
+        anchors.left: parent.left
+        anchors.leftMargin: 10
+        anchors.top: tcLabel.bottom
+        height: childrenRect.height
+
+        model: selectedPeopleModel
+        delegate: Text {
+            text: name
+            color: "grey"
+            font.pointSize: 15
+            lineHeight: 0.75
+            wrapMode: Text.WordWrap
+        }
+    }
+
+    Text {
+        id: currentLoopLabel
+        objectName: "currentLoopLabel"
+        color: "blue"
+        text: jokerWindow.currentLoopLabel
+        wrapMode: Text.WordWrap
+        font.pointSize: 50
+        anchors.bottom: leftColumn.bottom
+        anchors.left: leftColumn.left
+        anchors.leftMargin: 10
+        anchors.bottomMargin: 0
+    }
+}

--- a/app/Joker/LeftColumn.qml
+++ b/app/Joker/LeftColumn.qml
@@ -16,23 +16,42 @@ Item {
         anchors.left: parent.left
     }
 
-    Item {
+    Column {
+        objectName: "infos"
         anchors.top: tcLabel.bottom
         anchors.left: parent.left
         anchors.leftMargin: 10
 
-        ListView {
-            objectName: "infoList"
-            height: childrenRect.height
+        Text {
+            text: jokerWindow.updateInfo
+            color: "red"
+            font.pointSize: tcLabel.font.pointSize
+            lineHeight: 0.75
+            wrapMode: Text.WordWrap
+        }
 
-            model: infoModel
-            delegate: Text {
-                text: modelData
-                color: "red"
-                font.pointSize: tcLabel.font.pointSize
-                lineHeight: 0.75
-                wrapMode: Text.WordWrap
-            }
+        Text {
+            text: jokerWindow.refreshInfo
+            color: "red"
+            font.pointSize: tcLabel.font.pointSize
+            lineHeight: 0.75
+            wrapMode: Text.WordWrap
+        }
+
+        Text {
+            text: jokerWindow.dropInfo
+            color: "red"
+            font.pointSize: tcLabel.font.pointSize
+            lineHeight: 0.75
+            wrapMode: Text.WordWrap
+        }
+
+        Text {
+            text: jokerWindow.stripInfo
+            color: "red"
+            font.pointSize: tcLabel.font.pointSize
+            lineHeight: 0.75
+            wrapMode: Text.WordWrap
         }
     }
 

--- a/app/Joker/LeftColumn.qml
+++ b/app/Joker/LeftColumn.qml
@@ -9,11 +9,12 @@ Item {
         id: tcLabel
         objectName: "tcLabel"
         color: "#00ff00"
-        text: "#"
+        text: tcLabelText
         wrapMode: Text.WordWrap
         font.pointSize: 29
         anchors.top: parent.top
         anchors.left: parent.left
+        visible: tcLabelVisible
     }
 
     Column {
@@ -21,6 +22,7 @@ Item {
         anchors.top: tcLabel.bottom
         anchors.left: parent.left
         anchors.leftMargin: 10
+        visible: infosVisible
 
         Text {
             text: jokerWindow.updateInfo
@@ -61,6 +63,7 @@ Item {
         anchors.leftMargin: 10
         anchors.top: tcLabel.bottom
         height: childrenRect.height
+        visible: selectedPeopleListVisible
 
         model: selectedPeopleModel
         delegate: Text {

--- a/app/Joker/LeftColumn.qml
+++ b/app/Joker/LeftColumn.qml
@@ -64,7 +64,7 @@ Item {
 
         model: selectedPeopleModel
         delegate: Text {
-            text: name
+            text: display
             color: "grey"
             font.pointSize: 15
             lineHeight: 0.75

--- a/app/Joker/MediaPanel.qml
+++ b/app/Joker/MediaPanel.qml
@@ -1,0 +1,23 @@
+import QtQuick 2.0
+
+Rectangle {
+    width: 300
+    height: 120
+    color: "#0d0d0d"
+    radius: 0
+    border.width: 1
+    border.color: "#6d7dff"
+
+    Text {
+        id: text1
+        x: 72
+        y: 8
+        color: "#ffffff"
+        text: qsTr("#####")
+        textFormat: Text.PlainText
+        horizontalAlignment: Text.AlignHCenter
+        font.bold: true
+        styleColor: "#ffffff"
+        font.pixelSize: 38
+    }
+}

--- a/app/Joker/MediaPanel.qml
+++ b/app/Joker/MediaPanel.qml
@@ -1,23 +1,60 @@
 import QtQuick 2.0
+import QtQuick.Controls 1.2
 
 Rectangle {
     width: 300
     height: 120
-    color: "#0d0d0d"
+    color: "#aa0d0d0d"
     radius: 0
     border.width: 1
-    border.color: "#6d7dff"
+    border.color: "#aa6d7dff"
 
-    Text {
-        id: text1
-        x: 72
-        y: 8
-        color: "#ffffff"
-        text: qsTr("#####")
-        textFormat: Text.PlainText
-        horizontalAlignment: Text.AlignHCenter
-        font.bold: true
-        styleColor: "#ffffff"
-        font.pixelSize: 38
+    Column {
+        anchors.fill: parent
+
+        Text {
+            id: mediaPanelTcLabel
+            y: 8
+            anchors.horizontalCenter: parent.horizontalCenter
+            color: "#ffffff"
+            text: tcLabelText
+            horizontalAlignment: Text.AlignHCenter
+            font.bold: true
+            styleColor: "#ffffff"
+            font.pixelSize: 38
+        }
+
+        Row {
+
+            Button {
+                objectName: "BackButton"
+                text: "Back"
+            }
+
+            Button {
+                objectName: "FastRewindButton"
+                text: "FR"
+            }
+
+            Button {
+                objectName: "PreviousFrameButton"
+                text: "<<"
+            }
+
+            Button {
+                objectName: "PlayButton"
+                text: "Play/Pause"
+            }
+
+            Button {
+                objectName: "NextFrameButton"
+                text: ">>"
+            }
+
+            Button {
+                objectName: "FastForwardButton"
+                text: "FF"
+            }
+        }
     }
 }

--- a/app/Joker/PeopleDialog.cpp
+++ b/app/Joker/PeopleDialog.cpp
@@ -13,11 +13,12 @@
 
 #include "PeopleEditionDialog.h"
 
-PeopleDialog::PeopleDialog(QWidget *parent, PhStripDoc* doc, JokerSettings *settings) :
+PeopleDialog::PeopleDialog(QWidget *parent, PhStripDoc* doc, JokerSettings *settings, QStringListModel *selectedPeopleModel) :
 	QDialog(parent),
 	ui(new Ui::PeopleDialog),
 	_doc(doc),
-	_settings(settings)
+	_settings(settings),
+	_selectedPeopleModel(selectedPeopleModel)
 {
 	ui->setupUi(this);
 
@@ -61,8 +62,10 @@ void PeopleDialog::on_peopleList_itemSelectionChanged()
 		peopleNameList.append(item->text());
 	}
 
-	if(peopleNameList.count() < _doc->peoples().count())
+	if(peopleNameList.count() < _doc->peoples().count()) {
 		_settings->setSelectedPeopleNameList(peopleNameList);
+		_selectedPeopleModel->setStringList(peopleNameList);
+	}
 
 	ui->changeCharButton->setEnabled(ui->peopleList->selectedItems().count() == 1);
 }
@@ -74,6 +77,7 @@ void PeopleDialog::on_buttonBox_rejected()
 		peopleNameList.append(name);
 
 	_settings->setSelectedPeopleNameList(peopleNameList);
+	_selectedPeopleModel->setStringList(peopleNameList);
 }
 
 void PeopleDialog::on_deselectAllButton_clicked()

--- a/app/Joker/PeopleDialog.h
+++ b/app/Joker/PeopleDialog.h
@@ -7,7 +7,9 @@
 #ifndef PEOPLEDIALOG_H
 #define PEOPLEDIALOG_H
 
+
 #include <QDialog>
+#include <QStringListModel>
 
 #include "PhStrip/PhStripDoc.h"
 
@@ -38,7 +40,7 @@ public:
 	 * @param doc The current PhStripDoc
 	 * @param settings The application settings
 	 */
-	explicit PeopleDialog(QWidget *parent, PhStripDoc* doc, JokerSettings *settings);
+	explicit PeopleDialog(QWidget *parent, PhStripDoc* doc, JokerSettings *settings, QStringListModel *selectedPeopleModel);
 
 	~PeopleDialog();
 
@@ -56,6 +58,7 @@ private:
 	PhStripDoc* _doc;
 	JokerSettings *_settings;
 	QStringList _oldPeopleNameList;
+	QStringListModel *_selectedPeopleModel;
 };
 
 #endif // PEOPLEDIALOG_H

--- a/app/Joker/RightColumn.qml
+++ b/app/Joker/RightColumn.qml
@@ -8,12 +8,13 @@ Item {
         id: nextTcLabel
         objectName: "nextTcLabel"
         color: "red"
-        text: "#"
+        text: nextTcLabelText
         wrapMode: Text.WordWrap
         font.pointSize: 29
         anchors.top: parent.top
         anchors.right: parent.right
         horizontalAlignment: Text.AlignRight
+        visible: nextTcLabelVisible
     }
 
     ListView {

--- a/app/Joker/RightColumn.qml
+++ b/app/Joker/RightColumn.qml
@@ -31,18 +31,18 @@ Item {
 
             // FIXME inverted colors are not implemented
             delegate: Rectangle {
-                color: model.modelData.selected ? "#b0b0b0b0" : "#b0707070"
+                color: selected ? "#b0b0b0b0" : "#b0707070"
                 height: childrenRect.height + 2
                 width: childrenRect.width + 2
                 // y is relative to the parent
-                y: nextPeopleList.height - (model.modelData.timeIn - clockTime) / verticalTimePerPixel - height
+                y: nextPeopleList.height - (timeIn - clockTime) / verticalTimePerPixel - height
                 anchors.right: nextPeopleList.right
                 antialiasing: true // without antialiasing the jump from one pixel line to the next is visible
                 visible: name.length > 0 // do not draw when the name is empty
 
                 Text {
                     text: name
-                    color: model.modelData.color
+                    color: color
                     font.pointSize: 15
                     wrapMode: Text.WordWrap
                     horizontalAlignment: Text.AlignHCenter // FIXME does not work

--- a/app/Joker/RightColumn.qml
+++ b/app/Joker/RightColumn.qml
@@ -93,7 +93,6 @@ Item {
                 y: -height/2
                 height: 3
                 rotation: 45
-                transformOrigin: Center
             }
 
             Rectangle {
@@ -105,7 +104,6 @@ Item {
                 y: -height/2
                 height: 3
                 rotation: -45
-                transformOrigin: Center
             }
         }
     }

--- a/app/Joker/RightColumn.qml
+++ b/app/Joker/RightColumn.qml
@@ -16,39 +16,38 @@ Item {
         horizontalAlignment: Text.AlignRight
     }
 
-//    Item {
-//        id: nextPeopleList
-//        objectName: "nextPeopleList"
-//        anchors.top: nextTcLabel.bottom
-//        anchors.bottom: parent.bottom
-//        anchors.left: parent.left
-//        anchors.right: parent.right
-//        anchors.rightMargin: 2
-//        clip: true
-//        visible: false
+    Item {
+        id: nextPeopleList
+        objectName: "nextPeopleList"
+        anchors.top: nextTcLabel.bottom
+        anchors.bottom: parent.bottom
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.rightMargin: 2
+        clip: true
 
-//        Repeater {
-//            model: nextPeopleModel
+        Repeater {
+            model: nextPeopleModel
 
-//            // FIXME inverted colors are not implemented
-//            delegate: Rectangle {
-//                color: model.modelData.selected ? "#b0b0b0b0" : "#b0707070"
-//                height: childrenRect.height + 2
-//                width: childrenRect.width + 2
-//                // y is relative to the parent
-//                y: nextPeopleList.height - (model.modelData.timeIn - clockTime) / verticalTimePerPixel - height
-//                anchors.right: nextPeopleList.right
-//                antialiasing: true // without antialiasing the jump from one pixel line to the next is visible
-//                visible: name.length > 0 // do not draw when the name is empty
+            // FIXME inverted colors are not implemented
+            delegate: Rectangle {
+                color: model.modelData.selected ? "#b0b0b0b0" : "#b0707070"
+                height: childrenRect.height + 2
+                width: childrenRect.width + 2
+                // y is relative to the parent
+                y: nextPeopleList.height - (model.modelData.timeIn - clockTime) / verticalTimePerPixel - height
+                anchors.right: nextPeopleList.right
+                antialiasing: true // without antialiasing the jump from one pixel line to the next is visible
+                visible: name.length > 0 // do not draw when the name is empty
 
-//                Text {
-//                    text: name
-//                    color: model.modelData.color
-//                    font.pointSize: 15
-//                    wrapMode: Text.WordWrap
-//                    horizontalAlignment: Text.AlignHCenter // FIXME does not work
-//                }
-//            }
-//        }
-//    }
+                Text {
+                    text: name
+                    color: model.modelData.color
+                    font.pointSize: 15
+                    wrapMode: Text.WordWrap
+                    horizontalAlignment: Text.AlignHCenter // FIXME does not work
+                }
+            }
+        }
+    }
 }

--- a/app/Joker/RightColumn.qml
+++ b/app/Joker/RightColumn.qml
@@ -58,4 +58,54 @@ Item {
             }
         }
     }
+
+    // loops
+    ListView {
+        anchors.top: nextTcLabel.bottom
+        anchors.bottom: parent.bottom
+        anchors.right: parent.right
+        width: parent.width/2
+        orientation: ListView.Vertical
+        contentY:  -height -jokerWindow.stripTime / verticalTimePerPixel
+        verticalLayoutDirection: "BottomToTop"
+        interactive: false
+        model: loopModel
+        delegate: Item {
+            id: loopContainer
+            height: duration/verticalTimePerPixel
+            width: parent.width
+
+            Rectangle {
+                color: "white"
+                anchors.left: parent.left
+                anchors.right: parent.right
+                y: -height/2
+                height: 3
+            }
+
+            Rectangle {
+                color: "white"
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.leftMargin: parent.width*2/5
+                anchors.rightMargin: parent.width*2/5
+                y: -height/2
+                height: 3
+                rotation: 45
+                transformOrigin: Center
+            }
+
+            Rectangle {
+                color: "white"
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.leftMargin: parent.width*2/5
+                anchors.rightMargin: parent.width*2/5
+                y: -height/2
+                height: 3
+                rotation: -45
+                transformOrigin: Center
+            }
+        }
+    }
 }

--- a/app/Joker/RightColumn.qml
+++ b/app/Joker/RightColumn.qml
@@ -16,38 +16,39 @@ Item {
         horizontalAlignment: Text.AlignRight
     }
 
-    Item {
-        id: nextPeopleList
-        objectName: "nextPeopleList"
-        anchors.top: nextTcLabel.bottom
-        anchors.bottom: parent.bottom
-        anchors.left: parent.left
-        anchors.right: parent.right
-        anchors.rightMargin: 2
-        clip: true
+//    Item {
+//        id: nextPeopleList
+//        objectName: "nextPeopleList"
+//        anchors.top: nextTcLabel.bottom
+//        anchors.bottom: parent.bottom
+//        anchors.left: parent.left
+//        anchors.right: parent.right
+//        anchors.rightMargin: 2
+//        clip: true
+//        visible: false
 
-        Repeater {
-            model: nextPeopleModel
+//        Repeater {
+//            model: nextPeopleModel
 
-            // FIXME inverted colors are not implemented
-            delegate: Rectangle {
-                color: model.modelData.selected ? "#b0b0b0b0" : "#b0707070"
-                height: childrenRect.height + 2
-                width: childrenRect.width + 2
-                // y is relative to the parent
-                y: nextPeopleList.height - (model.modelData.timeIn - clockTime) / verticalTimePerPixel - height
-                anchors.right: nextPeopleList.right
-                antialiasing: true // without antialiasing the jump from one pixel line to the next is visible
-                visible: name.length > 0 // do not draw when the name is empty
+//            // FIXME inverted colors are not implemented
+//            delegate: Rectangle {
+//                color: model.modelData.selected ? "#b0b0b0b0" : "#b0707070"
+//                height: childrenRect.height + 2
+//                width: childrenRect.width + 2
+//                // y is relative to the parent
+//                y: nextPeopleList.height - (model.modelData.timeIn - clockTime) / verticalTimePerPixel - height
+//                anchors.right: nextPeopleList.right
+//                antialiasing: true // without antialiasing the jump from one pixel line to the next is visible
+//                visible: name.length > 0 // do not draw when the name is empty
 
-                Text {
-                    text: name
-                    color: model.modelData.color
-                    font.pointSize: 15
-                    wrapMode: Text.WordWrap
-                    horizontalAlignment: Text.AlignHCenter // FIXME does not work
-                }
-            }
-        }
-    }
+//                Text {
+//                    text: name
+//                    color: model.modelData.color
+//                    font.pointSize: 15
+//                    wrapMode: Text.WordWrap
+//                    horizontalAlignment: Text.AlignHCenter // FIXME does not work
+//                }
+//            }
+//        }
+//    }
 }

--- a/app/Joker/RightColumn.qml
+++ b/app/Joker/RightColumn.qml
@@ -1,0 +1,53 @@
+import QtQuick 2.0
+
+Item {
+    width: 300
+    height: 500
+
+    Text {
+        id: nextTcLabel
+        objectName: "nextTcLabel"
+        color: "red"
+        text: "#"
+        wrapMode: Text.WordWrap
+        font.pointSize: 29
+        anchors.top: parent.top
+        anchors.right: parent.right
+        horizontalAlignment: Text.AlignRight
+    }
+
+    Item {
+        id: nextPeopleList
+        objectName: "nextPeopleList"
+        anchors.top: nextTcLabel.bottom
+        anchors.bottom: parent.bottom
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.rightMargin: 2
+        clip: true
+
+        Repeater {
+            model: nextPeopleModel
+
+            // FIXME inverted colors are not implemented
+            delegate: Rectangle {
+                color: model.modelData.selected ? "#b0b0b0b0" : "#b0707070"
+                height: childrenRect.height + 2
+                width: childrenRect.width + 2
+                // y is relative to the parent
+                y: nextPeopleList.height - (model.modelData.timeIn - clockTime) / verticalTimePerPixel - height
+                anchors.right: nextPeopleList.right
+                antialiasing: true // without antialiasing the jump from one pixel line to the next is visible
+                visible: name.length > 0 // do not draw when the name is empty
+
+                Text {
+                    text: name
+                    color: model.modelData.color
+                    font.pointSize: 15
+                    wrapMode: Text.WordWrap
+                    horizontalAlignment: Text.AlignHCenter // FIXME does not work
+                }
+            }
+        }
+    }
+}

--- a/app/Joker/RightColumn.qml
+++ b/app/Joker/RightColumn.qml
@@ -25,7 +25,7 @@ Item {
         anchors.right: parent.right
         anchors.rightMargin: 2
         orientation: ListView.Vertical
-        contentY:  -height -clockTime / verticalTimePerPixel
+        contentY:  -height -jokerWindow.stripTime / verticalTimePerPixel
         verticalLayoutDirection: "BottomToTop"
         interactive: false
         clip: true

--- a/app/Joker/RightColumn.qml
+++ b/app/Joker/RightColumn.qml
@@ -16,7 +16,7 @@ Item {
         horizontalAlignment: Text.AlignRight
     }
 
-    Item {
+    ListView {
         id: nextPeopleList
         objectName: "nextPeopleList"
         anchors.top: nextTcLabel.bottom
@@ -24,19 +24,27 @@ Item {
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.rightMargin: 2
+        orientation: ListView.Vertical
+        contentY:  -height -clockTime / verticalTimePerPixel
+        verticalLayoutDirection: "BottomToTop"
+        interactive: false
         clip: true
 
-        Repeater {
-            model: nextPeopleModel
+        model: nextPeopleModel
 
-            // FIXME inverted colors are not implemented
-            delegate: Rectangle {
+        // FIXME inverted colors are not implemented
+        delegate: Item {
+            width: parent.width
+            height: duration / verticalTimePerPixel
+            x:0
+
+            Rectangle {
                 color: selected ? "#b0b0b0b0" : "#b0707070"
                 height: childrenRect.height + 2
                 width: childrenRect.width + 2
-                // y is relative to the parent
-                y: nextPeopleList.height - (timeIn - clockTime) / verticalTimePerPixel - height
-                anchors.right: nextPeopleList.right
+                anchors.bottom: parent.bottom
+                anchors.right: parent.right
+
                 antialiasing: true // without antialiasing the jump from one pixel line to the next is visible
                 visible: name.length > 0 // do not draw when the name is empty
 

--- a/app/Joker/Strip.qml
+++ b/app/Joker/Strip.qml
@@ -111,4 +111,58 @@ Item {
             }
         }
     }
+
+    ListView {
+        anchors.fill: parent
+        orientation: ListView.Horizontal
+        contentX: jokerWindow.stripTime / horizontalTimePerPixel - width / 6
+        interactive: false
+        model: loopModel
+        delegate: Item {
+            id: loopContainer
+            width: duration/horizontalTimePerPixel
+            height: parent.height
+
+            Rectangle {
+                color: invertColor? "white":"black"
+                anchors.top: parent.top
+                anchors.bottom: parent.bottom
+                x: parent.width - width/2
+                width: parent.height / 40
+            }
+
+            Rectangle {
+                color: invertColor? "white":"black"
+                anchors.top: parent.top
+                anchors.bottom: parent.bottom
+                anchors.topMargin: parent.height/3
+                anchors.bottomMargin: parent.height/3
+                x: parent.width - width/2
+                width: parent.height / 40
+                rotation: 45
+                transformOrigin: Center
+            }
+
+            Rectangle {
+                color: invertColor? "white":"black"
+                anchors.top: parent.top
+                anchors.bottom: parent.bottom
+                anchors.topMargin: parent.height/3
+                anchors.bottomMargin: parent.height/3
+                x: parent.width - width/2
+                width: parent.height / 40
+                rotation: -45
+                transformOrigin: Center
+            }
+
+            Text {
+                text: name
+                color: "gray"
+                font.pixelSize: parent.height/4
+                font.family: "Arial"
+                x: parent.width + 10
+                y: parent.height * 2 / 3
+            }
+        }
+    }
 }

--- a/app/Joker/Strip.qml
+++ b/app/Joker/Strip.qml
@@ -18,7 +18,7 @@ Item {
 
             // FIXME inverted colors are not implemented
             delegate: Item {
-                x: (model.modelData.timeIn - clockTime) / horizontalTimePerPixel + stripTexts.width / 6
+                x: (model.modelData.timeIn - jokerWindow.stripTime) / horizontalTimePerPixel + stripTexts.width / 6
                 y: model.modelData.y * stripTexts.height
                 transform: Scale { xScale: (model.modelData.timeOut - model.modelData.timeIn) / horizontalTimePerPixel / childrenRect.width;
                                    yScale: model.modelData.height*stripTexts.height / childrenRect.height}

--- a/app/Joker/Strip.qml
+++ b/app/Joker/Strip.qml
@@ -73,61 +73,15 @@ Item {
             }
 
             Text {
-                id: stripText
+                id: stripTextItem
                 text: content
                 font.pixelSize: parent.height
                 font.family: stripFont.name
                 font.weight: textBoldness * 99/5
-                transform: Scale {  xScale: stripTextContainer.width/stripText.width;
+                transform: Scale {  xScale: stripTextContainer.width/stripTextItem.width;
                                     yScale: 1;}
                 smooth: true // smooth scaling
             }
-        }
-    }
-
-    ColumnLayout {
-        anchors.fill: parent
-        spacing: 0
-
-        ListView {
-            Layout.fillHeight: true
-            Layout.fillWidth: true
-            orientation: ListView.Horizontal
-            contentX: jokerWindow.stripTime / horizontalTimePerPixel - width / 6
-            interactive: false
-            model: stripTextModelTrack0
-            delegate: stripTextDelegate
-        }
-
-
-        ListView {
-            Layout.fillHeight: true
-            Layout.fillWidth: true
-            orientation: ListView.Horizontal
-            contentX: jokerWindow.stripTime / horizontalTimePerPixel - width / 6
-            interactive: false
-            model: stripTextModelTrack1
-            delegate: stripTextDelegate
-        }
-
-        ListView {
-            Layout.fillHeight: true
-            Layout.fillWidth: true
-            orientation: ListView.Horizontal
-            contentX: jokerWindow.stripTime / horizontalTimePerPixel - width / 6
-            interactive: false
-            model: stripTextModelTrack2
-            delegate: stripTextDelegate
-        }
-
-        ListView {
-            Layout.fillHeight: true
-            Layout.fillWidth: true
-            orientation: ListView.Horizontal
-            contentX: jokerWindow.stripTime / horizontalTimePerPixel - width / 6
-            interactive: false
-            model: stripTextModelTrack3
-            delegate: stripTextDelegate
         }
     }
 
@@ -151,49 +105,41 @@ Item {
         }
     }
 
+    Component {
+        id: trackDelegate
+        Item {
+            Layout.fillHeight: true
+            Layout.fillWidth: true
+
+            ListView {
+                width: parent.width
+                height: parent.height
+                orientation: ListView.Horizontal
+                contentX: jokerWindow.stripTime / horizontalTimePerPixel - width / 6
+                interactive: false
+                model: stripPeople
+                delegate: stripPeopleDelegate
+            }
+
+            ListView {
+                width: parent.width
+                height: parent.height
+                orientation: ListView.Horizontal
+                contentX: jokerWindow.stripTime / horizontalTimePerPixel - width / 6
+                interactive: false
+                model: stripText
+                delegate: stripTextDelegate
+            }
+        }
+    }
+
     ColumnLayout {
         anchors.fill: parent
         spacing: 0
 
-        ListView {
-            Layout.fillHeight: true
-            Layout.fillWidth: true
-            orientation: ListView.Horizontal
-            contentX: jokerWindow.stripTime / horizontalTimePerPixel - width / 6
-            interactive: false
-            model: stripPeopleModelTrack0
-            delegate: stripPeopleDelegate
-        }
-
-
-        ListView {
-            Layout.fillHeight: true
-            Layout.fillWidth: true
-            orientation: ListView.Horizontal
-            contentX: jokerWindow.stripTime / horizontalTimePerPixel - width / 6
-            interactive: false
-            model: stripPeopleModelTrack1
-            delegate: stripPeopleDelegate
-        }
-
-        ListView {
-            Layout.fillHeight: true
-            Layout.fillWidth: true
-            orientation: ListView.Horizontal
-            contentX: jokerWindow.stripTime / horizontalTimePerPixel - width / 6
-            interactive: false
-            model: stripPeopleModelTrack2
-            delegate: stripPeopleDelegate
-        }
-
-        ListView {
-            Layout.fillHeight: true
-            Layout.fillWidth: true
-            orientation: ListView.Horizontal
-            contentX: jokerWindow.stripTime / horizontalTimePerPixel - width / 6
-            interactive: false
-            model: stripPeopleModelTrack3
-            delegate: stripPeopleDelegate
+        Repeater {
+            model: trackModel
+            delegate: trackDelegate
         }
     }
 

--- a/app/Joker/Strip.qml
+++ b/app/Joker/Strip.qml
@@ -4,34 +4,79 @@ Item {
     width: 600
     height: 400
 
-    Item {
+//    Item {
+//        id: stripTexts
+//        objectName: "stripTexts"
+//        anchors.top: parent.top
+//        anchors.bottom: parent.bottom
+//        anchors.left: parent.left
+//        anchors.right: parent.right
+//        clip: true
+//        //contentX: clockTime / horizontalTimePerPixel
+
+//        Repeater {
+//            model: stripTextModel
+
+//            // FIXME inverted colors are not implemented
+//            delegate: Item {
+//                //x: (model.modelData.timeIn - clockTime) / horizontalTimePerPixel + stripTexts.width / 6
+//                x: model.modelData.timeIn / horizontalTimePerPixel + stripTexts.width / 6
+//                y: model.modelData.y * stripTexts.height
+//                transform: Scale { xScale: (model.modelData.timeOut - model.modelData.timeIn) / horizontalTimePerPixel / childrenRect.width;
+//                                   yScale: model.modelData.height*stripTexts.height / childrenRect.height}
+
+//                Text {
+//                    text: model.modelData.content
+//                    // FIXME color and font not implemented
+//                    //color: model.modelData.color
+//                    font.pixelSize: model.modelData.height*stripTexts.height
+//                    font.family: "Arial"
+//                    wrapMode: Text.WordWrap
+//                    font.weight: Font.Black
+//                }
+//            }
+//        }
+//    }
+
+    ListView {
         id: stripTexts
         objectName: "stripTexts"
         anchors.top: parent.top
         anchors.bottom: parent.bottom
         anchors.left: parent.left
         anchors.right: parent.right
-        clip: true
+        //clip: true
+        contentX: clockTime / horizontalTimePerPixel
+        //cacheBuffer: 1000
+        //horizontalVelocity: 100000
+        //layer.enabled: true
 
-        Repeater {
-            model: stripTextModel
+        model: stripTextModel
 
-            // FIXME inverted colors are not implemented
-            delegate: Item {
-                x: (model.modelData.timeIn - clockTime) / horizontalTimePerPixel + stripTexts.width / 6
-                y: model.modelData.y * stripTexts.height
-                transform: Scale { xScale: (model.modelData.timeOut - model.modelData.timeIn) / horizontalTimePerPixel / childrenRect.width;
-                                   yScale: model.modelData.height*stripTexts.height / childrenRect.height}
+        // FIXME inverted colors are not implemented
+        delegate: Item {
+            //x: (model.modelData.timeIn - clockTime) / horizontalTimePerPixel + stripTexts.width / 6
+            x: model.modelData.timeIn / horizontalTimePerPixel + stripTexts.width / 6
+            y: model.modelData.y * stripTexts.height
+            transform: Scale { xScale: (model.modelData.timeOut - model.modelData.timeIn) / horizontalTimePerPixel / childrenRect.width;
+                               yScale: model.modelData.height*stripTexts.height / childrenRect.height}
+            //layer.enabled: true
 
-                Text {
-                    text: model.modelData.content
-                    // FIXME color and font not implemented
-                    //color: model.modelData.color
-                    font.pixelSize: model.modelData.height*stripTexts.height
-                    font.family: "Arial"
-                    wrapMode: Text.WordWrap
-                    font.weight: Font.Black
-                }
+//            Rectangle {
+//                color: "red"
+//                width: 200
+//                height: 20
+//            }
+
+            Text {
+                text: model.modelData.content
+                // FIXME color and font not implemented
+                //color: model.modelData.color
+                font.pixelSize: model.modelData.height*stripTexts.height
+                font.family: "Arial"
+                wrapMode: Text.WordWrap
+                font.weight: Font.Black
+                //layer.enabled: true
             }
         }
     }

--- a/app/Joker/Strip.qml
+++ b/app/Joker/Strip.qml
@@ -43,7 +43,6 @@ Item {
             orientation: ListView.Horizontal
             contentX: jokerWindow.stripTime / horizontalTimePerPixel - width / 6
             interactive: false
-            clip: true
             model: stripTextModelTrack0
             delegate: stripTextDelegate
         }
@@ -55,7 +54,6 @@ Item {
             orientation: ListView.Horizontal
             contentX: jokerWindow.stripTime / horizontalTimePerPixel - width / 6
             interactive: false
-            clip: true
             model: stripTextModelTrack1
             delegate: stripTextDelegate
         }
@@ -66,7 +64,6 @@ Item {
             orientation: ListView.Horizontal
             contentX: jokerWindow.stripTime / horizontalTimePerPixel - width / 6
             interactive: false
-            clip: true
             model: stripTextModelTrack2
             delegate: stripTextDelegate
         }
@@ -77,7 +74,6 @@ Item {
             orientation: ListView.Horizontal
             contentX: jokerWindow.stripTime / horizontalTimePerPixel - width / 6
             interactive: false
-            clip: true
             model: stripTextModelTrack3
             delegate: stripTextDelegate
         }

--- a/app/Joker/Strip.qml
+++ b/app/Joker/Strip.qml
@@ -1,0 +1,38 @@
+import QtQuick 2.0
+
+Item {
+    width: 600
+    height: 400
+
+    Item {
+        id: stripTexts
+        objectName: "stripTexts"
+        anchors.top: parent.top
+        anchors.bottom: parent.bottom
+        anchors.left: parent.left
+        anchors.right: parent.right
+        clip: true
+
+        Repeater {
+            model: stripTextModel
+
+            // FIXME inverted colors are not implemented
+            delegate: Item {
+                x: (model.modelData.timeIn - clockTime) / horizontalTimePerPixel + stripTexts.width / 6
+                y: model.modelData.y * stripTexts.height
+                transform: Scale { xScale: (model.modelData.timeOut - model.modelData.timeIn) / horizontalTimePerPixel / childrenRect.width;
+                                   yScale: model.modelData.height*stripTexts.height / childrenRect.height}
+
+                Text {
+                    text: model.modelData.content
+                    // FIXME color and font not implemented
+                    //color: model.modelData.color
+                    font.pixelSize: model.modelData.height*stripTexts.height
+                    font.family: "Arial"
+                    wrapMode: Text.WordWrap
+                    font.weight: Font.Black
+                }
+            }
+        }
+    }
+}

--- a/app/Joker/Strip.qml
+++ b/app/Joker/Strip.qml
@@ -29,6 +29,7 @@ Item {
                 text: content
                 font.pixelSize: parent.height
                 font.family: stripFont.name
+                font.weight: textBoldness * 99/5
                 transform: Scale {  xScale: stripTextContainer.width/stripText.width;
                                     yScale: 1;}
                 smooth: true // smooth scaling

--- a/app/Joker/Strip.qml
+++ b/app/Joker/Strip.qml
@@ -5,6 +5,9 @@ Item {
     width: 600
     height: 400
 
+    // the font name is passed from here
+    FontLoader { id: stripFont; source: textFontUrl }
+
     // FIXME color, font, inverted color are not implemented
     Component {
         id: stripTextDelegate
@@ -25,7 +28,7 @@ Item {
                 id: stripText
                 text: content
                 font.pixelSize: parent.height
-                font.family: "Arial"
+                font.family: stripFont.name
                 transform: Scale {  xScale: stripTextContainer.width/stripText.width;
                                     yScale: 1;}
                 smooth: true // smooth scaling

--- a/app/Joker/Strip.qml
+++ b/app/Joker/Strip.qml
@@ -8,6 +8,54 @@ Item {
     // the font name is passed from here
     FontLoader { id: stripFont; source: textFontUrl }
 
+    // ruler
+    ListView {
+        anchors.fill: parent
+        orientation: ListView.Horizontal
+        contentX: jokerWindow.stripTime / horizontalTimePerPixel - width / 6
+        interactive: false
+        model: rulerModel
+        visible: displayRuler
+        delegate: Item {
+            width: duration/horizontalTimePerPixel
+            height: parent.height
+
+            Rectangle {
+                color: invertColor? "white":"#808080"
+                anchors.top: parent.top
+                width: 1000/horizontalTimePerPixel
+                x: -width/2
+                height: parent.height/2
+            }
+
+            Rectangle {
+                color: invertColor? "white":"#808080"
+                anchors.top: parent.top
+                width: 1000/horizontalTimePerPixel
+                x: -width/2 + parent.width/2
+                height: parent.height/2
+            }
+
+            // ruler disc
+            Rectangle {
+                width: 4000/horizontalTimePerPixel
+                height: width
+                color: invertColor? "white":"#808080"
+                radius: width*0.5
+                x: parent.width/2 - width/2
+                y: parent.height/2 + width/4
+            }
+
+            Text {
+                color: invertColor? "white":"#808080"
+                x: -width/2
+                y: parent.height/2
+                text: name
+                font.pixelSize: parent.height/3
+            }
+        }
+    }
+
     // FIXME color, font, inverted color are not implemented
     Component {
         id: stripTextDelegate
@@ -148,7 +196,6 @@ Item {
             delegate: stripPeopleDelegate
         }
     }
-
 
     // sync bar
     Rectangle {

--- a/app/Joker/Strip.qml
+++ b/app/Joker/Strip.qml
@@ -2,8 +2,11 @@ import QtQuick 2.0
 import QtQuick.Layouts 1.1
 
 Item {
+    id: stripContainer
     width: 600
     height: 400
+
+    property int contentX: jokerWindow.stripTime / horizontalTimePerPixel - width / 6
 
     // the font name is passed from here
     FontLoader { id: stripFont; source: textFontUrl }
@@ -271,7 +274,7 @@ Item {
                 width: parent.width
                 height: parent.height
                 orientation: ListView.Horizontal
-                contentX: jokerWindow.stripTime / horizontalTimePerPixel - width / 6
+                contentX: stripContainer.contentX
                 interactive: false
                 model: stripPeople
                 delegate: stripPeopleDelegate
@@ -281,7 +284,7 @@ Item {
                 width: parent.width
                 height: parent.height
                 orientation: ListView.Horizontal
-                contentX: jokerWindow.stripTime / horizontalTimePerPixel - width / 6
+                contentX: stripContainer.contentX
                 interactive: false
                 model: stripText
                 delegate: stripTextDelegate
@@ -291,7 +294,7 @@ Item {
                 width: parent.width
                 height: parent.height
                 orientation: ListView.Horizontal
-                contentX: jokerWindow.stripTime / horizontalTimePerPixel - width / 6
+                contentX: stripContainer.contentX
                 interactive: false
                 model: offDetect
                 delegate: offDetectDelegate
@@ -301,7 +304,7 @@ Item {
                 width: parent.width
                 height: parent.height
                 orientation: ListView.Horizontal
-                contentX: jokerWindow.stripTime / horizontalTimePerPixel - width / 6
+                contentX: stripContainer.contentX
                 interactive: false
                 model: semiOffDetect
                 delegate: semiOffDetectDelegate
@@ -311,7 +314,7 @@ Item {
                 width: parent.width
                 height: parent.height
                 orientation: ListView.Horizontal
-                contentX: jokerWindow.stripTime / horizontalTimePerPixel - width / 6
+                contentX: stripContainer.contentX
                 interactive: false
                 model: arrowUpDetect
                 delegate: arrowUpDetectDelegate
@@ -321,7 +324,7 @@ Item {
                 width: parent.width
                 height: parent.height
                 orientation: ListView.Horizontal
-                contentX: jokerWindow.stripTime / horizontalTimePerPixel - width / 6
+                contentX: stripContainer.contentX
                 interactive: false
                 model: arrowDownDetect
                 delegate: arrowDownDetectDelegate
@@ -351,7 +354,7 @@ Item {
     ListView {
         anchors.fill: parent
         orientation: ListView.Horizontal
-        contentX: jokerWindow.stripTime / horizontalTimePerPixel - width / 6
+        contentX: stripContainer.contentX
         interactive: false
         model: cutModel
         visible: displayCuts
@@ -372,7 +375,7 @@ Item {
     ListView {
         anchors.fill: parent
         orientation: ListView.Horizontal
-        contentX: jokerWindow.stripTime / horizontalTimePerPixel - width / 6
+        contentX: stripContainer.contentX
         interactive: false
         model: loopModel
         delegate: Item {

--- a/app/Joker/Strip.qml
+++ b/app/Joker/Strip.qml
@@ -82,4 +82,12 @@ Item {
             delegate: stripTextDelegate
         }
     }
+
+    Rectangle {
+        x: parent.width/6
+        y: 0
+        width: 4
+        height: parent.height
+        color: "#FFFF566C"
+    }
 }

--- a/app/Joker/Strip.qml
+++ b/app/Joker/Strip.qml
@@ -29,10 +29,12 @@ Item {
     ListView {
         anchors.fill: parent
         orientation: ListView.Horizontal
-        contentX: jokerWindow.stripTime / horizontalTimePerPixel - width / 6
+        contentX: stripContainer.contentX
         interactive: false
         model: rulerModel
         visible: displayRuler
+        cacheBuffer: 2*stripContainer.width
+
         delegate: Item {
             width: duration/horizontalTimePerPixel
             height: parent.height
@@ -278,6 +280,7 @@ Item {
                 interactive: false
                 model: stripPeople
                 delegate: stripPeopleDelegate
+                cacheBuffer: 2*stripContainer.width
             }
 
             ListView {
@@ -288,6 +291,7 @@ Item {
                 interactive: false
                 model: stripText
                 delegate: stripTextDelegate
+                cacheBuffer: 2*stripContainer.width
             }
 
             ListView {
@@ -298,6 +302,7 @@ Item {
                 interactive: false
                 model: offDetect
                 delegate: offDetectDelegate
+                cacheBuffer: 2*stripContainer.width
             }
 
             ListView {
@@ -308,6 +313,7 @@ Item {
                 interactive: false
                 model: semiOffDetect
                 delegate: semiOffDetectDelegate
+                cacheBuffer: 2*stripContainer.width
             }
 
             ListView {
@@ -318,6 +324,7 @@ Item {
                 interactive: false
                 model: arrowUpDetect
                 delegate: arrowUpDetectDelegate
+                cacheBuffer: 2*stripContainer.width
             }
 
             ListView {
@@ -328,6 +335,7 @@ Item {
                 interactive: false
                 model: arrowDownDetect
                 delegate: arrowDownDetectDelegate
+                cacheBuffer: 2*stripContainer.width
             }
         }
     }
@@ -358,6 +366,8 @@ Item {
         interactive: false
         model: cutModel
         visible: displayCuts
+        cacheBuffer: 2*stripContainer.width
+
         delegate: Item {
             width: duration/horizontalTimePerPixel
             height: parent.height
@@ -378,6 +388,8 @@ Item {
         contentX: stripContainer.contentX
         interactive: false
         model: loopModel
+        cacheBuffer: 2*stripContainer.width
+
         delegate: Item {
             id: loopContainer
             width: duration/horizontalTimePerPixel

--- a/app/Joker/Strip.qml
+++ b/app/Joker/Strip.qml
@@ -4,79 +4,34 @@ Item {
     width: 600
     height: 400
 
-//    Item {
-//        id: stripTexts
-//        objectName: "stripTexts"
-//        anchors.top: parent.top
-//        anchors.bottom: parent.bottom
-//        anchors.left: parent.left
-//        anchors.right: parent.right
-//        clip: true
-//        //contentX: clockTime / horizontalTimePerPixel
-
-//        Repeater {
-//            model: stripTextModel
-
-//            // FIXME inverted colors are not implemented
-//            delegate: Item {
-//                //x: (model.modelData.timeIn - clockTime) / horizontalTimePerPixel + stripTexts.width / 6
-//                x: model.modelData.timeIn / horizontalTimePerPixel + stripTexts.width / 6
-//                y: model.modelData.y * stripTexts.height
-//                transform: Scale { xScale: (model.modelData.timeOut - model.modelData.timeIn) / horizontalTimePerPixel / childrenRect.width;
-//                                   yScale: model.modelData.height*stripTexts.height / childrenRect.height}
-
-//                Text {
-//                    text: model.modelData.content
-//                    // FIXME color and font not implemented
-//                    //color: model.modelData.color
-//                    font.pixelSize: model.modelData.height*stripTexts.height
-//                    font.family: "Arial"
-//                    wrapMode: Text.WordWrap
-//                    font.weight: Font.Black
-//                }
-//            }
-//        }
-//    }
-
-    ListView {
+    Item {
         id: stripTexts
         objectName: "stripTexts"
         anchors.top: parent.top
         anchors.bottom: parent.bottom
         anchors.left: parent.left
         anchors.right: parent.right
-        //clip: true
-        contentX: clockTime / horizontalTimePerPixel
-        //cacheBuffer: 1000
-        //horizontalVelocity: 100000
-        //layer.enabled: true
+        clip: true
 
-        model: stripTextModel
+        Repeater {
+            model: stripTextModel
 
-        // FIXME inverted colors are not implemented
-        delegate: Item {
-            //x: (model.modelData.timeIn - clockTime) / horizontalTimePerPixel + stripTexts.width / 6
-            x: model.modelData.timeIn / horizontalTimePerPixel + stripTexts.width / 6
-            y: model.modelData.y * stripTexts.height
-            transform: Scale { xScale: (model.modelData.timeOut - model.modelData.timeIn) / horizontalTimePerPixel / childrenRect.width;
-                               yScale: model.modelData.height*stripTexts.height / childrenRect.height}
-            //layer.enabled: true
+            // FIXME inverted colors are not implemented
+            delegate: Item {
+                x: (model.modelData.timeIn - clockTime) / horizontalTimePerPixel + stripTexts.width / 6
+                y: model.modelData.y * stripTexts.height
+                transform: Scale { xScale: (model.modelData.timeOut - model.modelData.timeIn) / horizontalTimePerPixel / childrenRect.width;
+                                   yScale: model.modelData.height*stripTexts.height / childrenRect.height}
 
-//            Rectangle {
-//                color: "red"
-//                width: 200
-//                height: 20
-//            }
-
-            Text {
-                text: model.modelData.content
-                // FIXME color and font not implemented
-                //color: model.modelData.color
-                font.pixelSize: model.modelData.height*stripTexts.height
-                font.family: "Arial"
-                wrapMode: Text.WordWrap
-                font.weight: Font.Black
-                //layer.enabled: true
+                Text {
+                    text: model.modelData.content
+                    // FIXME color and font not implemented
+                    //color: model.modelData.color
+                    font.pixelSize: model.modelData.height*stripTexts.height
+                    font.family: "Arial"
+                    wrapMode: Text.WordWrap
+                    font.weight: Font.Black
+                }
             }
         }
     }

--- a/app/Joker/Strip.qml
+++ b/app/Joker/Strip.qml
@@ -397,7 +397,6 @@ Item {
                 x: parent.width - width/2
                 width: parent.height / 40
                 rotation: 45
-                transformOrigin: Center
             }
 
             Rectangle {
@@ -409,7 +408,6 @@ Item {
                 x: parent.width - width/2
                 width: parent.height / 40
                 rotation: -45
-                transformOrigin: Center
             }
 
             Text {

--- a/app/Joker/Strip.qml
+++ b/app/Joker/Strip.qml
@@ -1,38 +1,85 @@
 import QtQuick 2.0
+import QtQuick.Layouts 1.1
 
 Item {
     width: 600
     height: 400
 
-    Item {
-        id: stripTexts
-        objectName: "stripTexts"
-        anchors.top: parent.top
-        anchors.bottom: parent.bottom
-        anchors.left: parent.left
-        anchors.right: parent.right
-        clip: true
+    // FIXME color, font, inverted color are not implemented
+    Component {
+        id: stripTextDelegate
+        Item {
+            id: stripTextContainer
+            width: (timeOut - timeIn)/horizontalTimePerPixel
+            height: parent.height
 
-        Repeater {
-            model: stripTextModel
-
-            // FIXME inverted colors are not implemented
-            delegate: Item {
-                x: (model.modelData.timeIn - jokerWindow.stripTime) / horizontalTimePerPixel + stripTexts.width / 6
-                y: model.modelData.y * stripTexts.height
-                transform: Scale { xScale: (model.modelData.timeOut - model.modelData.timeIn) / horizontalTimePerPixel / childrenRect.width;
-                                   yScale: model.modelData.height*stripTexts.height / childrenRect.height}
-
-                Text {
-                    text: model.modelData.content
-                    // FIXME color and font not implemented
-                    //color: model.modelData.color
-                    font.pixelSize: model.modelData.height*stripTexts.height
-                    font.family: "Arial"
-                    wrapMode: Text.WordWrap
-                    font.weight: Font.Black
-                }
+            Rectangle {
+                border.width: 1
+                border.color: "#30000000"
+                color: "#00FFFFFF"
+                anchors.fill: parent
+                visible: content.length > 0
             }
+
+            Text {
+                id: stripText
+                text: content
+                font.pixelSize: parent.height
+                font.family: "Arial"
+                transform: Scale {  xScale: stripTextContainer.width/stripText.width;
+                                    yScale: 1;}
+                smooth: true // smooth scaling
+            }
+        }
+    }
+
+    ColumnLayout {
+        anchors.fill: parent
+        spacing: 0
+
+        ListView {
+            Layout.fillHeight: true
+            Layout.fillWidth: true
+            orientation: ListView.Horizontal
+            contentX: jokerWindow.stripTime / horizontalTimePerPixel - width / 6
+            interactive: false
+            clip: true
+            model: stripTextModelTrack0
+            delegate: stripTextDelegate
+        }
+
+
+        ListView {
+            Layout.fillHeight: true
+            Layout.fillWidth: true
+            orientation: ListView.Horizontal
+            contentX: jokerWindow.stripTime / horizontalTimePerPixel - width / 6
+            interactive: false
+            clip: true
+            model: stripTextModelTrack1
+            delegate: stripTextDelegate
+        }
+
+        ListView {
+            Layout.fillHeight: true
+            Layout.fillWidth: true
+            orientation: ListView.Horizontal
+            contentX: jokerWindow.stripTime / horizontalTimePerPixel - width / 6
+            interactive: false
+            clip: true
+            model: stripTextModelTrack2
+            delegate: stripTextDelegate
+        }
+
+        ListView {
+            Layout.fillHeight: true
+            Layout.fillWidth: true
+            orientation: ListView.Horizontal
+            contentX: jokerWindow.stripTime / horizontalTimePerPixel - width / 6
+            interactive: false
+            clip: true
+            model: stripTextModelTrack3
+            delegate: stripTextDelegate
         }
     }
 }

--- a/app/Joker/Strip.qml
+++ b/app/Joker/Strip.qml
@@ -8,6 +8,20 @@ Item {
     // the font name is passed from here
     FontLoader { id: stripFont; source: textFontUrl }
 
+    // background image
+    // TODO: inverted colors, solid color if background is disabled
+    Image {
+        id: stripBackground
+        objectName: "stripBackground"
+        source: stripBackgroundUrl
+        fillMode: Image.TileHorizontally
+        anchors.top: parent.top
+        x: 0
+        width: 2*parent.width
+        anchors.bottom: parent.bottom
+        transform: Translate { x: (-jokerWindow.stripTime / horizontalTimePerPixel - stripBackground.width/2 / 6) % (stripBackground.width/2) }
+    }
+
     // ruler
     ListView {
         anchors.fill: parent
@@ -115,6 +129,7 @@ Item {
                id: offCanvas
                anchors.fill: parent
                antialiasing: true
+               visible: content.length===0
 
                onPaint: paintCanvas();
 
@@ -140,6 +155,7 @@ Item {
                id: semiOffCanvas
                anchors.fill: parent
                antialiasing: true
+               visible: content.length===0
 
                onPaint: paintCanvas();
 
@@ -165,6 +181,7 @@ Item {
                id: arrowUpCanvas
                anchors.fill: parent
                antialiasing: true
+               visible: content.length===0
 
                onPaint: paintCanvas();
 
@@ -209,6 +226,7 @@ Item {
                id: arrowDownCanvas
                anchors.fill: parent
                antialiasing: true
+               visible: content.length===0
 
                onPaint: paintCanvas();
 

--- a/app/Joker/Strip.qml
+++ b/app/Joker/Strip.qml
@@ -106,6 +106,144 @@ Item {
     }
 
     Component {
+        id: offDetectDelegate
+        Item {
+            width: duration/horizontalTimePerPixel
+            height: parent.height
+
+            Canvas {
+               id: offCanvas
+               anchors.fill: parent
+               antialiasing: true
+
+               onPaint: paintCanvas();
+
+               function paintCanvas() {
+                   var ctx = offCanvas.getContext("2d");
+                   ctx.save();
+                   // color should be the same as the text
+                   ctx.fillStyle = "black";
+                   ctx.fillRect(0, arrowUpCanvas.height*9/10, arrowUpCanvas.width, arrowUpCanvas.height/10);
+                   ctx.restore();
+                }
+            }
+        }
+    }
+
+    Component {
+        id: semiOffDetectDelegate
+        Item {
+            width: duration/horizontalTimePerPixel
+            height: parent.height
+
+            Canvas {
+               id: semiOffCanvas
+               anchors.fill: parent
+               antialiasing: true
+
+               onPaint: paintCanvas();
+
+               function paintCanvas() {
+                   var ctx = semiOffCanvas.getContext("2d");
+                   ctx.save();
+                   // color should be the same as the text
+                   ctx.fillStyle = "grey";
+                   ctx.fillRect(0, arrowUpCanvas.height*9/10, arrowUpCanvas.width, arrowUpCanvas.height/10);
+                   ctx.restore();
+                }
+            }
+        }
+    }
+
+    Component {
+        id: arrowUpDetectDelegate
+        Item {
+            width: duration/horizontalTimePerPixel
+            height: parent.height
+
+            Canvas {
+               id: arrowUpCanvas
+               anchors.fill: parent
+               antialiasing: true
+
+               onPaint: paintCanvas();
+
+               function paintCanvas() {
+                   var ctx = arrowUpCanvas.getContext("2d");
+                   ctx.save();
+
+                   // color should be the same as the text
+                   ctx.fillStyle = "black";
+
+                   var thickness = arrowUpCanvas.height/10;
+                   var nose = arrowUpCanvas.height/3;
+
+                   ctx.beginPath();
+                   ctx.moveTo(0, thickness);
+                   ctx.lineTo(thickness, 0);
+                   ctx.lineTo(arrowUpCanvas.width, arrowUpCanvas.height - thickness);
+                   ctx.lineTo(arrowUpCanvas.width - thickness, arrowUpCanvas.height);
+                   ctx.closePath();
+                   ctx.fill();
+
+                   ctx.beginPath();
+                   ctx.moveTo(arrowUpCanvas.width, arrowUpCanvas.height);
+                   ctx.lineTo(arrowUpCanvas.width - nose, arrowUpCanvas.height);
+                   ctx.lineTo(arrowUpCanvas.width, arrowUpCanvas.height - nose);
+                   ctx.closePath();
+                   ctx.fill();
+
+                   ctx.restore();
+                }
+            }
+        }
+    }
+
+    Component {
+        id: arrowDownDetectDelegate
+        Item {
+            width: duration/horizontalTimePerPixel
+            height: parent.height
+
+            Canvas {
+               id: arrowDownCanvas
+               anchors.fill: parent
+               antialiasing: true
+
+               onPaint: paintCanvas();
+
+               function paintCanvas() {
+                   var ctx = arrowDownCanvas.getContext("2d");
+
+                   // color should be the same as the text
+                   ctx.fillStyle = "black";
+
+                   var thickness = arrowDownCanvas.height/10;
+                   var nose = arrowDownCanvas.height/3;
+
+                   ctx.beginPath();
+                   ctx.moveTo(arrowDownCanvas.width - thickness, arrowDownCanvas.height);
+                   ctx.lineTo(0, arrowDownCanvas.height - thickness);
+                   ctx.lineTo(thickness, arrowDownCanvas.height);
+                   ctx.lineTo(arrowDownCanvas.width, thickness);
+
+                   ctx.closePath();
+                   ctx.fill();
+
+                   ctx.beginPath();
+                   ctx.moveTo(arrowDownCanvas.width, 0);
+                   ctx.lineTo(arrowDownCanvas.width - nose, 0);
+                   ctx.lineTo(arrowDownCanvas.width, nose);
+                   ctx.closePath();
+                   ctx.fill();
+
+                   ctx.restore();
+                }
+            }
+        }
+    }
+
+    Component {
         id: trackDelegate
         Item {
             Layout.fillHeight: true
@@ -129,6 +267,46 @@ Item {
                 interactive: false
                 model: stripText
                 delegate: stripTextDelegate
+            }
+
+            ListView {
+                width: parent.width
+                height: parent.height
+                orientation: ListView.Horizontal
+                contentX: jokerWindow.stripTime / horizontalTimePerPixel - width / 6
+                interactive: false
+                model: offDetect
+                delegate: offDetectDelegate
+            }
+
+            ListView {
+                width: parent.width
+                height: parent.height
+                orientation: ListView.Horizontal
+                contentX: jokerWindow.stripTime / horizontalTimePerPixel - width / 6
+                interactive: false
+                model: semiOffDetect
+                delegate: semiOffDetectDelegate
+            }
+
+            ListView {
+                width: parent.width
+                height: parent.height
+                orientation: ListView.Horizontal
+                contentX: jokerWindow.stripTime / horizontalTimePerPixel - width / 6
+                interactive: false
+                model: arrowUpDetect
+                delegate: arrowUpDetectDelegate
+            }
+
+            ListView {
+                width: parent.width
+                height: parent.height
+                orientation: ListView.Horizontal
+                contentX: jokerWindow.stripTime / horizontalTimePerPixel - width / 6
+                interactive: false
+                model: arrowDownDetect
+                delegate: arrowDownDetectDelegate
             }
         }
     }

--- a/app/Joker/Strip.qml
+++ b/app/Joker/Strip.qml
@@ -90,4 +90,25 @@ Item {
         height: parent.height
         color: "#FFFF566C"
     }
+
+    ListView {
+        anchors.fill: parent
+        orientation: ListView.Horizontal
+        contentX: jokerWindow.stripTime / horizontalTimePerPixel - width / 6
+        interactive: false
+        model: cutModel
+        visible: displayCuts
+        delegate: Item {
+            width: duration/horizontalTimePerPixel
+            height: parent.height
+
+            Rectangle {
+                color: invertColor? "white":"black"
+                anchors.top: parent.top
+                anchors.bottom: parent.bottom
+                x: parent.width
+                width: cutWidth
+            }
+        }
+    }
 }

--- a/app/Joker/Strip.qml
+++ b/app/Joker/Strip.qml
@@ -83,6 +83,74 @@ Item {
         }
     }
 
+    // people names
+    // FIXME color, font, inverted color are not implemented
+    Component {
+        id: stripPeopleDelegate
+        Item {
+            width: (timeOut - timeIn)/horizontalTimePerPixel
+            height: parent.height
+
+            Text {
+                anchors.right: parent.right
+                anchors.rightMargin: 4000/horizontalTimePerPixel
+                text: content
+                font.pixelSize: parent.height*2/5
+                font.family: "Arial"
+                color: "blue"
+                smooth: true // smooth scaling
+            }
+        }
+    }
+
+    ColumnLayout {
+        anchors.fill: parent
+        spacing: 0
+
+        ListView {
+            Layout.fillHeight: true
+            Layout.fillWidth: true
+            orientation: ListView.Horizontal
+            contentX: jokerWindow.stripTime / horizontalTimePerPixel - width / 6
+            interactive: false
+            model: stripPeopleModelTrack0
+            delegate: stripPeopleDelegate
+        }
+
+
+        ListView {
+            Layout.fillHeight: true
+            Layout.fillWidth: true
+            orientation: ListView.Horizontal
+            contentX: jokerWindow.stripTime / horizontalTimePerPixel - width / 6
+            interactive: false
+            model: stripPeopleModelTrack1
+            delegate: stripPeopleDelegate
+        }
+
+        ListView {
+            Layout.fillHeight: true
+            Layout.fillWidth: true
+            orientation: ListView.Horizontal
+            contentX: jokerWindow.stripTime / horizontalTimePerPixel - width / 6
+            interactive: false
+            model: stripPeopleModelTrack2
+            delegate: stripPeopleDelegate
+        }
+
+        ListView {
+            Layout.fillHeight: true
+            Layout.fillWidth: true
+            orientation: ListView.Horizontal
+            contentX: jokerWindow.stripTime / horizontalTimePerPixel - width / 6
+            interactive: false
+            model: stripPeopleModelTrack3
+            delegate: stripPeopleDelegate
+        }
+    }
+
+
+    // sync bar
     Rectangle {
         x: parent.width/6
         y: 0

--- a/app/Joker/Video.qml
+++ b/app/Joker/Video.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.0
 import Joker 1.0
 import QtQml 2.2
-
+import QtMultimedia 5.0
 
 Item {
     id: videoOverlay
@@ -21,6 +21,16 @@ Item {
         //anchors.centerIn: videoOverlay
         //horizontalAlignment: Image.AlignHCenter
         //verticalAlignment: Image.AlignVCenter
+    }
+
+    VideoOutput {
+        id: videoOutput
+        source: videoSource
+        anchors.fill: parent
+        //anchors.top: parent.top
+        //anchors.left: parent.left
+        //width: 300
+        //height: 200
     }
 
     Rectangle {

--- a/app/Joker/Video.qml
+++ b/app/Joker/Video.qml
@@ -1,0 +1,63 @@
+import QtQuick 2.0
+import Joker 1.0
+import QtQml 2.2
+
+
+Item {
+    id: videoOverlay
+    width: 500
+    height: 700
+
+    Image {
+        objectName: "videoLogo"
+        //source property is set from C++
+        fillMode: Image.PreserveAspectFit
+        anchors.top: videoOverlay.top
+        anchors.left: videoOverlay.left
+        //width: 500
+        anchors.right: videoOverlay.right
+        anchors.bottom: videoOverlay.bottom
+        //anchors.horizontalCenter: parent.Center
+        //anchors.centerIn: videoOverlay
+        //horizontalAlignment: Image.AlignHCenter
+        //verticalAlignment: Image.AlignVCenter
+    }
+
+    Rectangle {
+        id: noSyncRect
+        color: "#c0500000"
+        anchors.leftMargin: -10
+        anchors.rightMargin: -10
+        anchors.bottomMargin: -2
+        anchors.topMargin: -2
+        anchors.fill: noSyncLabel
+        visible: noSyncLabel.visible
+        opacity: noSyncLabel.opacity
+    }
+
+    Text {
+        id: noSyncLabel
+        objectName: "noSyncLabel"
+        color: "red"
+        font.pointSize: 30
+        wrapMode: Text.WordWrap
+        text: qsTr("No video sync")
+        anchors.verticalCenter: videoOverlay.verticalCenter
+        anchors.horizontalCenter: videoOverlay.horizontalCenter
+        anchors.margins: 20
+        verticalAlignment: Text.AlignVCenter
+        horizontalAlignment: Text.AlignHCenter
+    }
+
+    LeftColumn {
+        anchors.left: videoOverlay.left
+        anchors.top: videoOverlay.top
+        anchors.bottom: videoOverlay.bottom
+    }
+
+    RightColumn {
+        anchors.right: videoOverlay.right
+        anchors.top: videoOverlay.top
+        anchors.bottom: videoOverlay.bottom
+    }
+}

--- a/app/Joker/Video.qml
+++ b/app/Joker/Video.qml
@@ -66,4 +66,10 @@ Item {
         anchors.top: videoOverlay.top
         anchors.bottom: videoOverlay.bottom
     }
+
+    MediaPanel {
+        anchors.left: videoOverlay.left
+        anchors.bottom: videoOverlay.bottom
+        anchors.right: videoOverlay.right
+    }
 }

--- a/app/Joker/Video.qml
+++ b/app/Joker/Video.qml
@@ -10,7 +10,7 @@ Item {
 
     Image {
         objectName: "videoLogo"
-        //source property is set from C++
+        source: videoLogoUrl
         fillMode: Image.PreserveAspectFit
         anchors.top: videoOverlay.top
         anchors.left: videoOverlay.left

--- a/app/Joker/Video.qml
+++ b/app/Joker/Video.qml
@@ -71,5 +71,8 @@ Item {
         anchors.left: videoOverlay.left
         anchors.bottom: videoOverlay.bottom
         anchors.right: videoOverlay.right
+        anchors.leftMargin: 20
+        anchors.rightMargin: 20
+        anchors.bottomMargin: 20
     }
 }

--- a/app/Joker/Video.qml
+++ b/app/Joker/Video.qml
@@ -1,5 +1,4 @@
 import QtQuick 2.0
-import Joker 1.0
 import QtQml 2.2
 import QtMultimedia 5.0
 
@@ -18,25 +17,14 @@ Item {
         objectName: "videoLogo"
         source: videoLogoUrl
         fillMode: Image.PreserveAspectFit
-        anchors.top: videoOverlay.top
-        anchors.left: videoOverlay.left
-        //width: 500
-        anchors.right: videoOverlay.right
-        anchors.bottom: videoOverlay.bottom
-        //anchors.horizontalCenter: parent.Center
-        //anchors.centerIn: videoOverlay
-        //horizontalAlignment: Image.AlignHCenter
-        //verticalAlignment: Image.AlignVCenter
+        anchors.fill: parent
+        visible: videoLogoVisible
     }
 
     VideoOutput {
         id: videoOutput
         source: videoSource
         anchors.fill: parent
-        //anchors.top: parent.top
-        //anchors.left: parent.left
-        //width: 300
-        //height: 200
     }
 
     Rectangle {
@@ -63,6 +51,8 @@ Item {
         anchors.margins: 20
         verticalAlignment: Text.AlignVCenter
         horizontalAlignment: Text.AlignHCenter
+        visible: noSyncLabelVisible
+        opacity: noSyncLabelOpacity
     }
 
     LeftColumn {

--- a/app/Joker/Video.qml
+++ b/app/Joker/Video.qml
@@ -8,6 +8,12 @@ Item {
     width: 500
     height: 700
 
+    // black background
+    Rectangle {
+        anchors.fill: parent
+        color: "black"
+    }
+
     Image {
         objectName: "videoLogo"
         source: videoLogoUrl

--- a/app/Joker/main.qml
+++ b/app/Joker/main.qml
@@ -5,7 +5,6 @@
  */
 
 import QtQuick 2.0
-import Joker 1.0
 import QtQml 2.2
 import QtQuick.Controls 1.2
 import QtQuick.Layouts 1.1
@@ -16,10 +15,6 @@ Item {
     width: 800
     height: 600
 
-    PhQmlView {
-        objectName: "PhQmlView"
-    }
-
     Rectangle {
         id: titleRect
         objectName: "titleRect"
@@ -28,6 +23,7 @@ Item {
         width: parent.width
         anchors.top: parent.top
         anchors.left: parent.left
+        visible: titleRectVisible
 
         Text {
             id: titleLabel

--- a/app/Joker/main.qml
+++ b/app/Joker/main.qml
@@ -38,29 +38,32 @@ Item {
         }
     }
 
-    Text {
-        id: tcLabel
-        objectName: "tcLabel"
-        color: "#00ff00"
-        text: "#"
+    Item {
+        anchors.top: titleRect.bottom
+        anchors.left: parent.left
+        anchors.right: parent.right
         anchors.topMargin: 0
         anchors.leftMargin: 2
-        wrapMode: Text.WordWrap
-        anchors.left: parent.left
-        anchors.top: titleRect.bottom
-        font.pointSize: 29
-    }
-
-    Text {
-        objectName: "nextTcLabel"
-        color: "red"
-        text: "#"
-        anchors.topMargin: 0
         anchors.rightMargin: 2
-        wrapMode: Text.WordWrap
-        anchors.right: parent.right
-        anchors.top: titleRect.bottom
-        font.pointSize: tcLabel.font.pointSize
+
+        Text {
+            id: tcLabel
+            objectName: "tcLabel"
+            color: "#00ff00"
+            text: "#"
+            wrapMode: Text.WordWrap
+            font.pointSize: 29
+        }
+
+        Text {
+            objectName: "nextTcLabel"
+            color: "red"
+            text: "#"
+            wrapMode: Text.WordWrap
+            font.pointSize: tcLabel.font.pointSize
+            width: parent.width
+            horizontalAlignment: Text.AlignRight
+        }
     }
 
     Rectangle {

--- a/app/Joker/main.qml
+++ b/app/Joker/main.qml
@@ -70,6 +70,23 @@ Item {
                 horizontalAlignment: Text.AlignRight
             }
         }
+
+        ListView {
+            objectName: "selectedPeopleList"
+            width: parent.width
+            height: childrenRect.height
+            anchors.left: parent.left
+            anchors.leftMargin: 10
+
+            model: selectedPeopleModel
+            delegate: Text {
+                text: name
+                color: "grey"
+                font.pointSize: 15
+                lineHeight: 0.75
+                wrapMode: Text.WordWrap
+            }
+        }
     }
 
     Image {

--- a/app/Joker/main.qml
+++ b/app/Joker/main.qml
@@ -6,149 +6,53 @@
 
 import QtQuick 2.0
 import Joker 1.0
+import QtQml 2.2
 
 Item {
     id: item1
 
-    width: 320
-    height: 480
+    width: 800
+    height: 600
 
     PhQmlView {
         objectName: "PhQmlView"
     }
 
-    Column {
+    Rectangle {
+        id: titleRect
+        objectName: "titleRect"
+        color: "#000080"
+        height: childrenRect.height
+        width: parent.width
         anchors.top: parent.top
         anchors.left: parent.left
-        anchors.right: parent.right
-        anchors.margins: 0
 
-        spacing: 0
-
-        move: Transition {
-            NumberAnimation { properties: "x,y"; duration: 100 }
-        }
-
-        Rectangle {
-            id: titleRect
-            objectName: "titleRect"
-            color: "#000080"
-            height: childrenRect.height
+        Text {
+            id: titleLabel
+            color: "white"
+            wrapMode: Text.WordWrap
+            text: doc.fullTitle
+            font.pointSize: 8
+            horizontalAlignment: Text.AlignHCenter
             width: parent.width
-
-            Text {
-                id: titleLabel
-                color: "white"
-                wrapMode: Text.WordWrap
-                text: doc.fullTitle
-                font.pointSize: 8
-                horizontalAlignment: Text.AlignHCenter
-                width: parent.width
-            }
-        }
-
-        Item {
-            width: parent.width
-            height: childrenRect.height
-
-            Text {
-                id: tcLabel
-                objectName: "tcLabel"
-                color: "#00ff00"
-                text: "#"
-                wrapMode: Text.WordWrap
-                font.pointSize: 29
-            }
-
-            Text {
-                objectName: "nextTcLabel"
-                color: "red"
-                text: "#"
-                wrapMode: Text.WordWrap
-                font.pointSize: tcLabel.font.pointSize
-                width: parent.width
-                horizontalAlignment: Text.AlignRight
-            }
-        }
-
-        ListView {
-            objectName: "selectedPeopleList"
-            width: parent.width
-            height: childrenRect.height
-            anchors.left: parent.left
-            anchors.leftMargin: 10
-
-            model: selectedPeopleModel
-            delegate: Text {
-                text: name
-                color: "grey"
-                font.pointSize: 15
-                lineHeight: 0.75
-                wrapMode: Text.WordWrap
-            }
-        }
-
-        ListView {
-            objectName: "infoList"
-            width: parent.width
-            height: childrenRect.height
-            anchors.left: parent.left
-            anchors.leftMargin: 10
-
-            model: infoModel
-            delegate: Text {
-                text: modelData
-                color: "red"
-                font.pointSize: tcLabel.font.pointSize
-                lineHeight: 0.75
-                wrapMode: Text.WordWrap
-            }
         }
     }
 
-    Image {
-        objectName: "videoLogo"
-        //source property is set from C++
-        fillMode: Image.PreserveAspectFit
-        anchors.top: titleRect.bottom
+    Video {
         anchors.left: parent.left
         anchors.right: parent.right
+        anchors.top: titleRect.visible ? titleRect.bottom : parent.top
+        anchors.bottom: stripPlaceholder.top
     }
 
-    Rectangle {
-        id: noSyncRect
-        color: "#c0500000"
-        anchors.leftMargin: -10
-        anchors.rightMargin: -10
-        anchors.bottomMargin: -2
-        anchors.topMargin: -2
-        anchors.fill: noSyncLabel
-        visible: noSyncLabel.visible
-        opacity: noSyncLabel.opacity
-    }
-
-    Text {
-        id: noSyncLabel
-        objectName: "noSyncLabel"
-        color: "red"
-        wrapMode: Text.WordWrap
-        text: qsTr("No video sync")
-        verticalAlignment: Text.AlignVCenter
-        anchors.verticalCenter: parent.verticalCenter
-        anchors.horizontalCenter: parent.horizontalCenter
-        font.pointSize: 30
-        horizontalAlignment: Text.AlignHCenter
-        anchors.margins: 20
-    }
-
-    Text {
-        objectName: "currentLoopLabel"
-        color: "blue"
-        text: jokerWindow.currentLoopLabel
-        wrapMode: Text.WordWrap
+    Item {
+        id: stripPlaceholder
+        objectName: "stripPlaceholder"
+        // height is set from C++
+        //height: 200
         anchors.left: parent.left
-        font.pointSize: 50
-        anchors.leftMargin: 10
+        anchors.right: parent.right
+        anchors.bottom: parent.bottom
     }
 }
 

--- a/app/Joker/main.qml
+++ b/app/Joker/main.qml
@@ -1,0 +1,39 @@
+/**
+ * @file
+ * @copyright (C) 2012-2014 Phonations
+ * @license http://www.gnu.org/licenses/gpl.html GPL version 2 or higher
+ */
+
+import QtQuick 2.0
+import Joker 1.0
+
+Item {
+
+    width: 320
+    height: 480
+
+    PhQmlView {
+        objectName: "PhQmlView"
+    }
+
+    Rectangle {
+        color: Qt.rgba(0.9, 1, 1, 0.7)
+        radius: 10
+        border.width: 1
+        border.color: "red"
+        anchors.fill: label
+        anchors.margins: -10
+    }
+
+    Text {
+        id: label
+        color: "black"
+        wrapMode: Text.WordWrap
+        text: "The background here is the Joker window rendered with raw OpenGL using the 'beforeRender()' signal in QQuickWindow. This text label and its border is rendered using QML"
+        anchors.right: parent.right
+        anchors.left: parent.left
+        anchors.bottom: parent.bottom
+        anchors.margins: 20
+    }
+}
+

--- a/app/Joker/main.qml
+++ b/app/Joker/main.qml
@@ -7,6 +7,8 @@
 import QtQuick 2.0
 import Joker 1.0
 import QtQml 2.2
+import QtQuick.Controls 1.2
+import QtQuick.Layouts 1.1
 
 Item {
     id: item1
@@ -38,21 +40,26 @@ Item {
         }
     }
 
-    Video {
+    SplitView {
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.top: titleRect.visible ? titleRect.bottom : parent.top
-        anchors.bottom: strip.top
-    }
-
-    Strip {
-        id: strip
-        objectName: "strip"
-        // height is set from C++
-        //height: 200
-        anchors.left: parent.left
-        anchors.right: parent.right
         anchors.bottom: parent.bottom
+
+        orientation: Qt.Vertical
+
+        Video {
+            Layout.fillHeight: true
+            Layout.minimumHeight: 50
+        }
+
+        Strip {
+            id: strip
+            objectName: "strip"
+            // TODO save and restore height on startup
+            height: 200
+            Layout.minimumHeight: 50
+        }
     }
 }
 

--- a/app/Joker/main.qml
+++ b/app/Joker/main.qml
@@ -17,52 +17,58 @@ Item {
         objectName: "PhQmlView"
     }
 
-    Rectangle {
-        id: titleRect
-        objectName: "titleRect"
-        color: "#000080"
-        anchors.fill: titleLabel
-        height: childrenRect.height
-        anchors.right: parent.right
-        anchors.left: parent.left
+    Column {
         anchors.top: parent.top
-
-        Text {
-            id: titleLabel
-            color: "white"
-            wrapMode: Text.WordWrap
-            text: doc.fullTitle
-            font.pointSize: 8
-            horizontalAlignment: Text.AlignHCenter
-            width: parent.width
-        }
-    }
-
-    Item {
-        anchors.top: titleRect.bottom
         anchors.left: parent.left
         anchors.right: parent.right
-        anchors.topMargin: 0
-        anchors.leftMargin: 2
-        anchors.rightMargin: 2
+        anchors.margins: 0
 
-        Text {
-            id: tcLabel
-            objectName: "tcLabel"
-            color: "#00ff00"
-            text: "#"
-            wrapMode: Text.WordWrap
-            font.pointSize: 29
+        spacing: 0
+
+        move: Transition {
+            NumberAnimation { properties: "x,y"; duration: 100 }
         }
 
-        Text {
-            objectName: "nextTcLabel"
-            color: "red"
-            text: "#"
-            wrapMode: Text.WordWrap
-            font.pointSize: tcLabel.font.pointSize
+        Rectangle {
+            id: titleRect
+            objectName: "titleRect"
+            color: "#000080"
+            height: childrenRect.height
             width: parent.width
-            horizontalAlignment: Text.AlignRight
+
+            Text {
+                id: titleLabel
+                color: "white"
+                wrapMode: Text.WordWrap
+                text: doc.fullTitle
+                font.pointSize: 8
+                horizontalAlignment: Text.AlignHCenter
+                width: parent.width
+            }
+        }
+
+        Item {
+            width: parent.width
+            height: childrenRect.height
+
+            Text {
+                id: tcLabel
+                objectName: "tcLabel"
+                color: "#00ff00"
+                text: "#"
+                wrapMode: Text.WordWrap
+                font.pointSize: 29
+            }
+
+            Text {
+                objectName: "nextTcLabel"
+                color: "red"
+                text: "#"
+                wrapMode: Text.WordWrap
+                font.pointSize: tcLabel.font.pointSize
+                width: parent.width
+                horizontalAlignment: Text.AlignRight
+            }
         }
     }
 

--- a/app/Joker/main.qml
+++ b/app/Joker/main.qml
@@ -72,6 +72,15 @@ Item {
         }
     }
 
+    Image {
+        objectName: "videoLogo"
+        //source property is set from C++
+        fillMode: Image.PreserveAspectFit
+        anchors.top: titleRect.bottom
+        anchors.left: parent.left
+        anchors.right: parent.right
+    }
+
     Rectangle {
         id: noSyncRect
         color: "#c0500000"

--- a/app/Joker/main.qml
+++ b/app/Joker/main.qml
@@ -87,6 +87,23 @@ Item {
                 wrapMode: Text.WordWrap
             }
         }
+
+        ListView {
+            objectName: "infoList"
+            width: parent.width
+            height: childrenRect.height
+            anchors.left: parent.left
+            anchors.leftMargin: 10
+
+            model: infoModel
+            delegate: Text {
+                text: modelData
+                color: "red"
+                font.pointSize: tcLabel.font.pointSize
+                lineHeight: 0.75
+                wrapMode: Text.WordWrap
+            }
+        }
     }
 
     Image {

--- a/app/Joker/main.qml
+++ b/app/Joker/main.qml
@@ -8,6 +8,7 @@ import QtQuick 2.0
 import Joker 1.0
 
 Item {
+    id: item1
 
     width: 320
     height: 480
@@ -41,6 +42,32 @@ Item {
         anchors.top: parent.top
         anchors.margins: 20
         visible: titleRect.visible
+    }
+
+    Rectangle {
+        id: noSyncRect
+        color: "#c0500000"
+        anchors.leftMargin: -10
+        anchors.rightMargin: -10
+        anchors.bottomMargin: -2
+        anchors.topMargin: -2
+        anchors.fill: noSyncLabel
+        visible: noSyncLabel.visible
+        opacity: noSyncLabel.opacity
+    }
+
+    Text {
+        id: noSyncLabel
+        objectName: "noSyncLabel"
+        color: "#ff0000"
+        wrapMode: Text.WordWrap
+        text: qsTr("No video sync")
+        verticalAlignment: Text.AlignVCenter
+        anchors.verticalCenter: parent.verticalCenter
+        anchors.horizontalCenter: parent.horizontalCenter
+        font.pointSize: 30
+        horizontalAlignment: Text.AlignHCenter
+        anchors.margins: 20
     }
 }
 

--- a/app/Joker/main.qml
+++ b/app/Joker/main.qml
@@ -21,27 +21,46 @@ Item {
         id: titleRect
         objectName: "titleRect"
         color: "#000080"
-        anchors.leftMargin: -20
-        anchors.rightMargin: -20
-        anchors.bottomMargin: -2
-        anchors.topMargin: -2
         anchors.fill: titleLabel
-        anchors.margins: -10
-    }
-
-    Text {
-        id: titleLabel
-        color: "white"
-        wrapMode: Text.WordWrap
-        text: doc.fullTitle
-        font.pointSize: 8
-        anchors.topMargin: 0
-        horizontalAlignment: Text.AlignHCenter
+        height: childrenRect.height
         anchors.right: parent.right
         anchors.left: parent.left
         anchors.top: parent.top
-        anchors.margins: 20
-        visible: titleRect.visible
+
+        Text {
+            id: titleLabel
+            color: "white"
+            wrapMode: Text.WordWrap
+            text: doc.fullTitle
+            font.pointSize: 8
+            horizontalAlignment: Text.AlignHCenter
+            width: parent.width
+        }
+    }
+
+    Text {
+        id: tcLabel
+        objectName: "tcLabel"
+        color: "#00ff00"
+        text: "#"
+        anchors.topMargin: 0
+        anchors.leftMargin: 2
+        wrapMode: Text.WordWrap
+        anchors.left: parent.left
+        anchors.top: titleRect.bottom
+        font.pointSize: 29
+    }
+
+    Text {
+        objectName: "nextTcLabel"
+        color: "red"
+        text: "#"
+        anchors.topMargin: 0
+        anchors.rightMargin: 2
+        wrapMode: Text.WordWrap
+        anchors.right: parent.right
+        anchors.top: titleRect.bottom
+        font.pointSize: tcLabel.font.pointSize
     }
 
     Rectangle {
@@ -78,31 +97,6 @@ Item {
         anchors.left: parent.left
         font.pointSize: 50
         anchors.leftMargin: 10
-    }
-
-    Text {
-        id: tcLabel
-        objectName: "tcLabel"
-        color: "#00ff00"
-        text: "#"
-        anchors.topMargin: 0
-        anchors.leftMargin: 2
-        wrapMode: Text.WordWrap
-        anchors.left: parent.left
-        anchors.top: titleRect.bottom
-        font.pointSize: 29
-    }
-
-    Text {
-        objectName: "nextTcLabel"
-        color: "red"
-        text: "#"
-        anchors.topMargin: 0
-        anchors.rightMargin: 2
-        wrapMode: Text.WordWrap
-        anchors.right: parent.right
-        anchors.top: titleRect.bottom
-        font.pointSize: tcLabel.font.pointSize
     }
 }
 

--- a/app/Joker/main.qml
+++ b/app/Joker/main.qml
@@ -17,23 +17,30 @@ Item {
     }
 
     Rectangle {
-        color: Qt.rgba(0.9, 1, 1, 0.7)
-        radius: 10
-        border.width: 1
-        border.color: "red"
-        anchors.fill: label
+        id: titleRect
+        objectName: "titleRect"
+        color: "#000080"
+        anchors.leftMargin: -20
+        anchors.rightMargin: -20
+        anchors.bottomMargin: -2
+        anchors.topMargin: -2
+        anchors.fill: titleLabel
         anchors.margins: -10
     }
 
     Text {
-        id: label
-        color: "black"
+        id: titleLabel
+        color: "#ffffff"
         wrapMode: Text.WordWrap
-        text: "The background here is the Joker window rendered with raw OpenGL using the 'beforeRender()' signal in QQuickWindow. This text label and its border is rendered using QML"
+        text: doc.fullTitle
+        font.pointSize: 8
+        anchors.topMargin: 0
+        horizontalAlignment: Text.AlignHCenter
         anchors.right: parent.right
         anchors.left: parent.left
-        anchors.bottom: parent.bottom
+        anchors.top: parent.top
         anchors.margins: 20
+        visible: titleRect.visible
     }
 }
 

--- a/app/Joker/main.qml
+++ b/app/Joker/main.qml
@@ -42,12 +42,12 @@ Item {
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.top: titleRect.visible ? titleRect.bottom : parent.top
-        anchors.bottom: stripPlaceholder.top
+        anchors.bottom: strip.top
     }
 
-    Item {
-        id: stripPlaceholder
-        objectName: "stripPlaceholder"
+    Strip {
+        id: strip
+        objectName: "strip"
         // height is set from C++
         //height: 200
         anchors.left: parent.left

--- a/app/Joker/main.qml
+++ b/app/Joker/main.qml
@@ -81,6 +81,7 @@ Item {
     }
 
     Text {
+        id: tcLabel
         objectName: "tcLabel"
         color: "#00ff00"
         text: "#"
@@ -90,6 +91,18 @@ Item {
         anchors.left: parent.left
         anchors.top: titleRect.bottom
         font.pointSize: 29
+    }
+
+    Text {
+        objectName: "nextTcLabel"
+        color: "red"
+        text: "#"
+        anchors.topMargin: 0
+        anchors.rightMargin: 2
+        wrapMode: Text.WordWrap
+        anchors.right: parent.right
+        anchors.top: titleRect.bottom
+        font.pointSize: tcLabel.font.pointSize
     }
 }
 

--- a/app/Joker/main.qml
+++ b/app/Joker/main.qml
@@ -31,7 +31,7 @@ Item {
 
     Text {
         id: titleLabel
-        color: "#ffffff"
+        color: "white"
         wrapMode: Text.WordWrap
         text: doc.fullTitle
         font.pointSize: 8
@@ -59,7 +59,7 @@ Item {
     Text {
         id: noSyncLabel
         objectName: "noSyncLabel"
-        color: "#ff0000"
+        color: "red"
         wrapMode: Text.WordWrap
         text: qsTr("No video sync")
         verticalAlignment: Text.AlignVCenter
@@ -68,6 +68,16 @@ Item {
         font.pointSize: 30
         horizontalAlignment: Text.AlignHCenter
         anchors.margins: 20
+    }
+
+    Text {
+        objectName: "currentLoopLabel"
+        color: "blue"
+        text: jokerWindow.currentLoopLabel
+        wrapMode: Text.WordWrap
+        anchors.left: parent.left
+        font.pointSize: 50
+        anchors.leftMargin: 10
     }
 }
 

--- a/app/Joker/main.qml
+++ b/app/Joker/main.qml
@@ -79,5 +79,17 @@ Item {
         font.pointSize: 50
         anchors.leftMargin: 10
     }
+
+    Text {
+        objectName: "tcLabel"
+        color: "#00ff00"
+        text: "#"
+        anchors.topMargin: 0
+        anchors.leftMargin: 2
+        wrapMode: Text.WordWrap
+        anchors.left: parent.left
+        anchors.top: titleRect.bottom
+        font.pointSize: 29
+    }
 }
 

--- a/common/deploy.pri
+++ b/common/deploy.pri
@@ -1,5 +1,5 @@
 win32 {
-	QMAKE_POST_LINK += $$(QTDIR)/bin/windeployqt $${RESOURCES_PATH} $${CS}
+	QMAKE_POST_LINK += $$(QTDIR)/bin/windeployqt --qmldir $$shell_path($${JOKER_ROOT}/app/Joker/) $$shell_path($${RESOURCES_PATH}/Joker.exe) $${CS}
 }
 
 CONFIG(release, debug|release) {

--- a/libs/PhCommonUI/PhMediaPanel.h
+++ b/libs/PhCommonUI/PhMediaPanel.h
@@ -133,13 +133,14 @@ public slots:
 	 */
 	void onTimeCodeTypeChanged(PhTimeCodeType tcType);
 
-private slots:
 	void onPlayPause();
 	void onFastForward();
 	void onRewind();
 	void onBack();
 	void onNextFrame();
 	void onPreviousFrame();
+
+private slots:
 	void onSliderChanged(int position);
 	void updateSlider();
 	void onTCTypeComboChanged();

--- a/libs/PhGraphic/PhGraphic.pri
+++ b/libs/PhGraphic/PhGraphic.pri
@@ -18,7 +18,8 @@ HEADERS += \
 	../../libs/PhGraphic/PhGraphicLoop.h \
 	../../libs/PhGraphic/PhGraphicDisc.h \
 	../../libs/PhGraphic/PhGraphicDashedLine.h \
-	../../libs/PhGraphic/PhGraphicArrow.h
+	../../libs/PhGraphic/PhGraphicArrow.h \
+    ../../libs/PhGraphic/PhQmlView.h
 
 SOURCES += \
 	../../libs/PhGraphic/PhGraphicView.cpp \
@@ -32,7 +33,8 @@ SOURCES += \
 	../../libs/PhGraphic/PhGraphicLoop.cpp \
 	../../libs/PhGraphic/PhGraphicDisc.cpp \
 	../../libs/PhGraphic/PhGraphicDashedLine.cpp \
-	../../libs/PhGraphic/PhGraphicArrow.cpp
+	../../libs/PhGraphic/PhGraphicArrow.cpp \
+    ../../libs/PhGraphic/PhQmlView.cpp
 
 # Windows specific
 win32 {

--- a/libs/PhGraphic/PhGraphicView.cpp
+++ b/libs/PhGraphic/PhGraphicView.cpp
@@ -18,7 +18,8 @@
 #include "PhGraphicView.h"
 
 PhGraphicView::PhGraphicView( QWidget *parent)
-	: QQuickWidget(parent),
+	//: QQuickWidget(parent),
+	: QQuickView(),
 	_settings(NULL),
 	_dropDetected(0),
 	_maxRefreshRate(0),
@@ -51,8 +52,8 @@ PhGraphicView::PhGraphicView( QWidget *parent)
 PhGraphicView::PhGraphicView(int width, int height, QWidget *parent)
 	: PhGraphicView(parent)
 {
-	int ratio = this->windowHandle()->devicePixelRatio();
-	this->setGeometry(0, 0, width / ratio, height / ratio);
+	//int ratio = this->windowHandle()->devicePixelRatio();
+	//this->setGeometry(0, 0, width / ratio, height / ratio);
 }
 
 PhGraphicView::~PhGraphicView()

--- a/libs/PhGraphic/PhGraphicView.cpp
+++ b/libs/PhGraphic/PhGraphicView.cpp
@@ -42,7 +42,7 @@ PhGraphicView::PhGraphicView( QWidget *parent)
 	else
 		PHDEBUG << "Unable to get the screen";
 
-	int timerInterval = 500 / _screenFrequency;
+	int timerInterval = 1000 / _screenFrequency;
 	_refreshTimer->start( timerInterval);
 	//PHDEBUG << "Refresh rate set to " << _screenFrequency << "hz, timer restart every" << timerInterval << "ms";
 	_dropTimer.start();

--- a/libs/PhGraphic/PhGraphicView.h
+++ b/libs/PhGraphic/PhGraphicView.h
@@ -7,7 +7,7 @@
 #ifndef PHGRAPHICVIEW_H
 #define PHGRAPHICVIEW_H
 
-#include <QGLWidget>
+#include <QQuickWidget>
 #include <QTimer>
 
 #include "PhSync/PhTime.h"
@@ -24,7 +24,7 @@
  * These methods are called automatically after the view creation and during all
  * its lifetime.
  */
-class PhGraphicView : public QGLWidget
+class PhGraphicView : public QQuickWidget
 {
 	Q_OBJECT
 public:
@@ -46,14 +46,6 @@ public:
 	PhGraphicView (int width, int height, QWidget *parent = 0);
 
 	~PhGraphicView();
-
-	/**
-	 * Handle the resizing of the view.
-	 *
-	 * @param width
-	 * @param height
-	 */
-	void resizeGL(int width, int height);
 
 	/**
 	 * @brief Get the refresh rate of the view
@@ -87,12 +79,6 @@ signals:
 	 */
 	void paint(int width, int height);
 protected:
-	/**
-	 * @brief paintGL
-	 * This virtual function is called whenever the widget needs to be painted.
-	 * Reimplement it in a subclass.
-	 */
-	void paintGL();
 
 	/**
 	 * @brief The screen frequency

--- a/libs/PhGraphic/PhGraphicView.h
+++ b/libs/PhGraphic/PhGraphicView.h
@@ -7,7 +7,8 @@
 #ifndef PHGRAPHICVIEW_H
 #define PHGRAPHICVIEW_H
 
-#include <QQuickWidget>
+//#include <QQuickWidget>
+#include <QQuickView>
 #include <QTimer>
 
 #include "PhSync/PhTime.h"
@@ -24,7 +25,8 @@
  * These methods are called automatically after the view creation and during all
  * its lifetime.
  */
-class PhGraphicView : public QQuickWidget
+//class PhGraphicView : public QQuickWidget
+class PhGraphicView : public QQuickView
 {
 	Q_OBJECT
 public:

--- a/libs/PhGraphic/PhGraphicView.h
+++ b/libs/PhGraphic/PhGraphicView.h
@@ -61,10 +61,30 @@ public:
 	 */
 	void setGraphicSettings(PhGraphicSettings *settings);
 	/**
-	 * @brief Add a line to the debug info
-	 * @param info A string
+	 * @brief measured max refresh rate
+	 * @return measured max refresh rate
 	 */
-	void addInfo(QString info);
+	int maxRefreshRate();
+	/**
+	 * @brief measured max update duration
+	 * @return measured max update duration
+	 */
+	int maxUpdateDuration();
+	/**
+	 * @brief measured last update duration
+	 * @return measured last update duration
+	 */
+	int lastUpdateDuration();
+	/**
+	 * @brief number of drops detected since the start of the application
+	 * @return number of drops detected
+	 */
+	int dropDetected();
+	/**
+	 * @brief number of seconds elapsed since last drop detected
+	 * @return number of seconds
+	 */
+	int secondsSinceLastDrop();
 signals:
 	/**
 	 * @brief emit a signal just before the paint
@@ -96,8 +116,6 @@ private:
 	 */
 	QTimer *_refreshTimer;
 	PhTickCounter _frameTickCounter;
-	QStringList _infos;
-	PhFont _infoFont;
 	QTime _dropTimer;
 	int _dropDetected, _maxRefreshRate, _maxPaintDuration, _lastUpdateDuration, _maxUpdateDuration;
 };

--- a/libs/PhGraphic/PhQmlView.cpp
+++ b/libs/PhGraphic/PhQmlView.cpp
@@ -1,0 +1,89 @@
+/**
+ * @file
+ * @copyright (C) 2012-2014 Phonations
+ * @license http://www.gnu.org/licenses/gpl.html GPL version 2 or higher
+ */
+
+#include "PhQmlView.h"
+
+#include <QtQuick/qquickwindow.h>
+#include <QtGui/QOpenGLContext>
+
+#include "PhTools/PhDebug.h"
+
+PhQmlView::PhQmlView()
+	: _openGLFunctions(NULL)
+{
+	connect(this, SIGNAL(windowChanged(QQuickWindow*)), this, SLOT(handleWindowChanged(QQuickWindow*)));
+}
+
+void PhQmlView::onRefresh()
+{
+	if (window())
+		window()->update();
+}
+
+void PhQmlView::handleWindowChanged(QQuickWindow *win)
+{
+	if (win) {
+		connect(win, SIGNAL(beforeSynchronizing()), this, SLOT(sync()), Qt::DirectConnection);
+		connect(win, SIGNAL(sceneGraphInvalidated()), this, SLOT(cleanup()), Qt::DirectConnection);
+
+		// If we allow QML to do the clearing, it would clear what we paint
+		// and nothing would show.
+		win->setClearBeforeRendering(false);
+
+		connect(win, SIGNAL(beforeRendering()), this, SLOT(onPaint()), Qt::DirectConnection);
+	}
+}
+
+void PhQmlView::cleanup()
+{
+}
+
+void PhQmlView::sync()
+{
+	if (window())
+		window()->update();
+}
+
+void PhQmlView::onPaint()
+{
+	if (_openGLFunctions == NULL) {
+		if (QOpenGLContext::currentContext()) {
+			_openGLFunctions = new QOpenGLFunctions(QOpenGLContext::currentContext());
+			_openGLFunctions->initializeOpenGLFunctions();
+		}
+	}
+
+	if (_openGLFunctions != NULL) {
+		// Enable the fixed-pipeline functionnality in OpenGL.
+		// By default it is disabled because Qt priority is to target OpenGL _ES_ where fixed pipeline does not exist.
+		_openGLFunctions->glUseProgram(0);
+	} else {
+		return;
+	}
+
+	glViewport(0, 0, window()->width(), window()->height());
+	glMatrixMode(GL_PROJECTION);
+	glPushMatrix();
+	glLoadIdentity();
+	glOrtho(0, window()->width(), window()->height(), 0, -10, 10);
+	glMatrixMode(GL_MODELVIEW);
+	glEnable(GL_DEPTH_TEST);
+	glDepthFunc(GL_LEQUAL);
+	glLoadIdentity();
+
+	// http://stackoverflow.com/questions/21870004/strange-bugs-while-rendering-with-opengl-under-qml-scene
+	//glDepthMask(GL_TRUE);
+
+	glClearColor(0, 0, 0, 1);
+	glClear( GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+
+	int ratio = window()->devicePixelRatio();
+	emit paint(window()->width() * ratio, window()->height() * ratio);
+
+	// try to restore the state to where it was before we touched it
+	glMatrixMode(GL_PROJECTION);
+	glPopMatrix();
+}

--- a/libs/PhGraphic/PhQmlView.cpp
+++ b/libs/PhGraphic/PhQmlView.cpp
@@ -49,41 +49,41 @@ void PhQmlView::sync()
 
 void PhQmlView::onPaint()
 {
-	if (_openGLFunctions == NULL) {
-		if (QOpenGLContext::currentContext()) {
-			_openGLFunctions = new QOpenGLFunctions(QOpenGLContext::currentContext());
-			_openGLFunctions->initializeOpenGLFunctions();
-		}
-	}
+//	if (_openGLFunctions == NULL) {
+//		if (QOpenGLContext::currentContext()) {
+//			_openGLFunctions = new QOpenGLFunctions(QOpenGLContext::currentContext());
+//			_openGLFunctions->initializeOpenGLFunctions();
+//		}
+//	}
 
-	if (_openGLFunctions != NULL) {
-		// Enable the fixed-pipeline functionnality in OpenGL.
-		// By default it is disabled because Qt priority is to target OpenGL _ES_ where fixed pipeline does not exist.
-		_openGLFunctions->glUseProgram(0);
-	} else {
-		return;
-	}
+//	if (_openGLFunctions != NULL) {
+//		// Enable the fixed-pipeline functionnality in OpenGL.
+//		// By default it is disabled because Qt priority is to target OpenGL _ES_ where fixed pipeline does not exist.
+//		_openGLFunctions->glUseProgram(0);
+//	} else {
+//		return;
+//	}
 
-	glViewport(0, 0, window()->width(), window()->height());
-	glMatrixMode(GL_PROJECTION);
-	glPushMatrix();
-	glLoadIdentity();
-	glOrtho(0, window()->width(), window()->height(), 0, -10, 10);
-	glMatrixMode(GL_MODELVIEW);
-	glEnable(GL_DEPTH_TEST);
-	glDepthFunc(GL_LEQUAL);
-	glLoadIdentity();
+//	glViewport(0, 0, window()->width(), window()->height());
+//	glMatrixMode(GL_PROJECTION);
+//	glPushMatrix();
+//	glLoadIdentity();
+//	glOrtho(0, window()->width(), window()->height(), 0, -10, 10);
+//	glMatrixMode(GL_MODELVIEW);
+//	glEnable(GL_DEPTH_TEST);
+//	glDepthFunc(GL_LEQUAL);
+//	glLoadIdentity();
 
 	// http://stackoverflow.com/questions/21870004/strange-bugs-while-rendering-with-opengl-under-qml-scene
 	//glDepthMask(GL_TRUE);
 
-	glClearColor(0, 0, 0, 1);
-	glClear( GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+//	glClearColor(0, 0, 0, 1);
+//	glClear( GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
 	int ratio = window()->devicePixelRatio();
 	emit paint(window()->width() * ratio, window()->height() * ratio);
 
 	// try to restore the state to where it was before we touched it
-	glMatrixMode(GL_PROJECTION);
-	glPopMatrix();
+//	glMatrixMode(GL_PROJECTION);
+//	glPopMatrix();
 }

--- a/libs/PhGraphic/PhQmlView.h
+++ b/libs/PhGraphic/PhQmlView.h
@@ -1,0 +1,42 @@
+/**
+ * @file
+ * @copyright (C) 2012-2014 Phonations
+ * @license http://www.gnu.org/licenses/gpl.html GPL version 2 or higher
+ */
+
+#ifndef PHQMLGRAPHICVIEW_H
+#define PHQMLGRAPHICVIEW_H
+
+#include <QtQuick/QQuickItem>
+#include <QtGui/QOpenGLFunctions>
+
+
+class PhQmlView : public QQuickItem
+{
+	Q_OBJECT
+
+public:
+	PhQmlView();
+
+signals:
+	/**
+	 * @brief paint event, every class have to re-implement it.
+	 * @param width Width of the paint area
+	 * @param height Height of the paint area
+	 */
+	void paint(int width, int height);
+
+public slots:
+	void sync();
+	void cleanup();
+	void onPaint();
+	void onRefresh();
+
+private slots:
+	void handleWindowChanged(QQuickWindow *win);
+
+private:
+	QOpenGLFunctions *_openGLFunctions;
+};
+
+#endif // PHQMLGRAPHICVIEW_H

--- a/libs/PhGraphicStrip/PhGraphicStrip.cpp
+++ b/libs/PhGraphicStrip/PhGraphicStrip.cpp
@@ -76,6 +76,19 @@ void PhGraphicStrip::onDocChanged()
 								_doc.timeOut() - text->timeIn());
 	_nextPeopleModel.addNextPeople(nextPeople);
 
+	// ruler
+	_rulerModel.clear();
+	PhTime rulerTimeIn = _settings->rulerTimeIn();
+	PhTime timeBetweenRuler = _settings->timeBetweenRuler();
+	PhTime rulerTime = rulerTimeIn;
+	PhTime docTimeOut = _doc.timeOut();
+	while (rulerTime < docTimeOut + timeBetweenRuler) {
+		int rulerNumber = (rulerTime - rulerTimeIn) / timeBetweenRuler;
+		PhNextPeople *rulerPeople = new PhNextPeople(QString::number(rulerNumber), "", rulerTime, true, timeBetweenRuler);
+		_rulerModel.addNextPeople(rulerPeople);
+		rulerTime += timeBetweenRuler;
+	}
+
 	// cuts
 	_cutModel.clear();
 	int previousCutTime = 0;
@@ -381,67 +394,6 @@ void PhGraphicStrip::draw(int x, int y, int width, int height, int tcOffset, QLi
 
 			backgroundRect.setZ(-2);
 			backgroundRect.draw();
-		}
-
-		if(_settings->displayRuler()) {
-			PhTime rulerTimeIn = _settings->rulerTimeIn();
-			PhTime timeBetweenRuler = _settings->timeBetweenRuler();
-			int rulerNumber = (timeIn - rulerTimeIn) / timeBetweenRuler;
-			if (rulerNumber < 0)
-				rulerNumber = 0;
-
-			PhTime rulerTime = rulerTimeIn + rulerNumber * timeBetweenRuler;
-			PhGraphicSolidRect rulerRect;
-			PhGraphicDisc rulerDisc;
-			PhGraphicText rulerText(&_hudFont);
-			QColor rulerColor(80, 80, 80);
-			if(invertedColor)
-				rulerColor = Qt::white;
-
-			int width = 1000 / timePerPixel;
-
-			rulerRect.setColor(rulerColor);
-			rulerRect.setWidth(width);
-			rulerRect.setHeight(height / 2);
-			rulerRect.setZ(0);
-			rulerRect.setY(y);
-
-			rulerDisc.setColor(rulerColor);
-			rulerDisc.setRadius(2 * width);
-			rulerDisc.setY(y + height / 2 + 3 * width);
-			rulerDisc.setZ(0);
-
-			rulerText.setColor(rulerColor);
-			rulerText.setY(y + height / 2);
-			rulerText.setHeight(height / 2);
-			rulerText.setZ(0);
-
-
-			while (rulerTime < timeOut + timeBetweenRuler) {
-				counter++;
-				int x = rulerTime / timePerPixel - offset;
-
-				rulerRect.setX(x - rulerRect.width() / 2);
-				rulerRect.draw();
-
-				QString text = QString::number(rulerNumber);
-				rulerText.setContent(text);
-				int textWidth = _hudFont.getNominalWidth(text);
-				rulerText.setWidth(textWidth);
-				rulerText.setX(x - textWidth / 2);
-				rulerText.draw();
-
-				x += timeBetweenRuler / timePerPixel / 2;
-
-				rulerRect.setX(x - rulerRect.width() / 2);
-				rulerRect.draw();
-
-				rulerDisc.setX(x);
-				rulerDisc.draw();
-
-				rulerNumber++;
-				rulerTime += timeBetweenRuler;
-			}
 		}
 
 		foreach(PhStripDetect * detect, _doc.detects()) {

--- a/libs/PhGraphicStrip/PhGraphicStrip.cpp
+++ b/libs/PhGraphicStrip/PhGraphicStrip.cpp
@@ -44,15 +44,37 @@ void PhGraphicStrip::onDocChanged()
 
 	_nextPeopleModel.clear();
 
-	foreach(PhStripText * text, _doc.texts()) {
+	if (_doc.texts().isEmpty())
+		return;
+
+	PhNextPeople *nextPeople = new PhNextPeople("",
+												"#000000",
+												0,
+												true,
+												_doc.texts().first()->timeIn());
+	_nextPeopleModel.addNextPeople(nextPeople);
+
+	for(int i=0; i<_doc.texts().length() - 1; i++)
+	{
+		PhStripText * text = _doc.texts()[i];
+		PhStripText * nextText = _doc.texts()[i+1];
 		PhPeople * people = text->people();
 		PhNextPeople *nextPeople = new PhNextPeople(people->name(),
 													computeColor(people, selectedPeoples, invertedColor).name(),
 													text->timeIn(),
-													selectedPeoples.size()==0 || selectedPeoples.contains(people));
+													selectedPeoples.size()==0 || selectedPeoples.contains(people),
+													nextText->timeIn() - text->timeIn());
 		_nextPeopleModel.addNextPeople(nextPeople);
 	}
 
+	PhStripText * text = _doc.texts().last();
+	PhPeople * people = text->people();
+	nextPeople = new PhNextPeople(people->name(),
+								computeColor(people, selectedPeoples, invertedColor).name(),
+								text->timeIn(),
+								selectedPeoples.size()==0 || selectedPeoples.contains(people),
+								_doc.timeOut() - text->timeIn());
+	_nextPeopleModel.addNextPeople(nextPeople);
 }
 
 PhFont *PhGraphicStrip::getTextFont()

--- a/libs/PhGraphicStrip/PhGraphicStrip.cpp
+++ b/libs/PhGraphicStrip/PhGraphicStrip.cpp
@@ -75,6 +75,81 @@ void PhGraphicStrip::onDocChanged()
 								selectedPeoples.size()==0 || selectedPeoples.contains(people),
 								_doc.timeOut() - text->timeIn());
 	_nextPeopleModel.addNextPeople(nextPeople);
+
+	// strip texts
+	_stripTextModelTrack0.clear();
+	_stripTextModelTrack1.clear();
+	_stripTextModelTrack2.clear();
+	_stripTextModelTrack3.clear();
+	int previousTimeOutTrack0 = 0;
+	int previousTimeOutTrack1 = 0;
+	int previousTimeOutTrack2 = 0;
+	int previousTimeOutTrack3 = 0;
+
+	foreach(PhStripText * text, _doc.texts()) {
+		text->setSelected(selectedPeoples.size()==0 || selectedPeoples.contains(text->people()));
+
+		if (text->y() == 0) {
+			PhStripText *emptyText = new PhStripText(previousTimeOutTrack0,
+													 text->people(),
+													 text->timeIn(),
+													 0,
+													 "", // empty content
+													 0, //height
+													 true);
+
+			_stripTextModelTrack0.addStripText(emptyText);
+			_stripTextModelTrack0.addStripText(text);
+
+			previousTimeOutTrack0 = text->timeOut();
+		}
+
+		if (text->y() == 0.25) {
+			PhStripText *emptyText = new PhStripText(previousTimeOutTrack1,
+													 text->people(),
+													 text->timeIn(),
+													 0,
+													 "", // empty content
+													 0, //height
+													 true);
+
+			_stripTextModelTrack1.addStripText(emptyText);
+			_stripTextModelTrack1.addStripText(text);
+
+			previousTimeOutTrack1 = text->timeOut();
+		}
+
+		if (text->y() == 0.5) {
+			PhStripText *emptyText = new PhStripText(previousTimeOutTrack2,
+													 text->people(),
+													 text->timeIn(),
+													 0,
+													 "", // empty content
+													 0, //height
+													 true);
+
+			_stripTextModelTrack2.addStripText(emptyText);
+			_stripTextModelTrack2.addStripText(text);
+
+			previousTimeOutTrack2 = text->timeOut();
+		}
+
+
+		if (text->y() == 0.75) {
+			PhStripText *emptyText = new PhStripText(previousTimeOutTrack3,
+													 text->people(),
+													 text->timeIn(),
+													 0,
+													 "", // empty content
+													 0, //height
+													 true);
+
+			_stripTextModelTrack3.addStripText(emptyText);
+			_stripTextModelTrack3.addStripText(text);
+
+			previousTimeOutTrack3 = text->timeOut();
+		}
+	}
 }
 
 PhFont *PhGraphicStrip::getTextFont()
@@ -288,20 +363,7 @@ void PhGraphicStrip::draw(int x, int y, int width, int height, int tcOffset, QLi
 		if(displayNextText)
 			maxTimeIn += y * verticalTimePerPixel;
 
-		// housekeeping !
-		//_nextPeoples.clear();
-		_stripTexts.clear();
-
 		foreach(PhStripText * text, _doc.texts()) {
-
-			if( !((text->timeOut() < timeIn) || (text->timeIn() > timeOut)) ) {
-				counter++;
-				// FIXME font and color not implemented
-				//PhGraphicText gText(&_textFont, text->content());
-				//gText.setColor(computeColor(text->people(), selectedPeoples, invertedColor));
-				_stripTexts.append(text);
-			}
-
 			PhPeople * people = text->people();
 			QString name = people ? people->name() : "???";
 			PhGraphicText gPeople(&_hudFont, name);
@@ -330,19 +392,6 @@ void PhGraphicStrip::draw(int x, int y, int width, int height, int tcOffset, QLi
 
 				gPeople.draw();
 			}
-
-//			if(displayNextText
-//			   && text->timeIn() - clockTime > -50*verticalTimePerPixel // make sure the label does not disappear suddenly
-//			   &&  text->timeIn() - clockTime < (y-tcOffset)*verticalTimePerPixel
-//			   && ((lastText == NULL)
-//			       || (lastText->people() != text->people())
-//			       || (text->timeIn() - lastText->timeOut() > minTimeBetweenPeople))) {
-//				PhNextPeople *nextPeople = new PhNextPeople(people->name(),
-//															computeColor(people, selectedPeoples, invertedColor).name(),
-//															text->timeIn(),
-//															selectedPeoples.size()==0 || selectedPeoples.contains(people));
-//				_nextPeoples.append(nextPeople);
-//			}
 
 			lastTextList[text->y()] = text;
 

--- a/libs/PhGraphicStrip/PhGraphicStrip.cpp
+++ b/libs/PhGraphicStrip/PhGraphicStrip.cpp
@@ -76,6 +76,15 @@ void PhGraphicStrip::onDocChanged()
 								_doc.timeOut() - text->timeIn());
 	_nextPeopleModel.addNextPeople(nextPeople);
 
+	// cuts
+	_cutModel.clear();
+	int previousCutTime = 0;
+	foreach(PhStripCut * cut, _doc.cuts()) {
+		PhNextPeople *cutPeople = new PhNextPeople("", "", previousCutTime, true, cut->timeIn() - previousCutTime);
+		_cutModel.addNextPeople(cutPeople);
+		previousCutTime = cut->timeIn();
+	}
+
 	// strip texts
 	_stripTextModelTrack0.clear();
 	_stripTextModelTrack1.clear();
@@ -390,31 +399,6 @@ void PhGraphicStrip::draw(int x, int y, int width, int height, int tcOffset, QLi
 
 			if(text->timeIn() > maxTimeIn)
 				break;
-		}
-
-		if(_settings->displayCuts()) {
-			int cutWidth = _settings->cutWidth();
-			foreach(PhStripCut * cut, _doc.cuts()) {
-				//_counter++;
-				if( (timeIn < cut->timeIn()) && (cut->timeIn() < timeOut)) {
-					PhGraphicSolidRect gCut;
-					gCut.setZ(-1);
-					gCut.setWidth(cutWidth);
-
-					if(invertedColor)
-						gCut.setColor(QColor(255, 255, 255));
-					else
-						gCut.setColor(QColor(0, 0, 0));
-					gCut.setHeight(height);
-					gCut.setX(x + cut->timeIn() / timePerPixel - offset);
-					gCut.setY(y);
-
-					gCut.draw();
-				}
-				//Doesn't need to process undisplayed content
-				if(cut->timeIn() > timeOut)
-					break;
-			}
 		}
 
 		foreach(PhStripLoop * loop, _doc.loops()) {

--- a/libs/PhGraphicStrip/PhGraphicStrip.cpp
+++ b/libs/PhGraphicStrip/PhGraphicStrip.cpp
@@ -529,7 +529,7 @@ void PhGraphicStrip::draw(int x, int y, int width, int height, int tcOffset, QLi
 	_testTimer.restart();
 
 	_infos.append(QString("Max strip draw: %1").arg(_maxDrawElapsed));
-	_infos.append(QString("Count: %1").arg(counter));
+	_infos.append(QString(" Count: %1").arg(counter));
 
 	if(_settings->resetInfo())
 		_maxDrawElapsed = 0;

--- a/libs/PhGraphicStrip/PhGraphicStrip.cpp
+++ b/libs/PhGraphicStrip/PhGraphicStrip.cpp
@@ -255,7 +255,14 @@ void PhGraphicStrip::draw(int x, int y, int width, int height, int tcOffset, QLi
 
 		// housekeeping !
 		_nextPeoples.clear();
-		_stripTexts.clear();
+		//_stripTexts.clear();
+
+		// append all strip texts !
+		if (_stripTexts.empty() && !_doc.texts().empty()) {
+			foreach(PhStripText * text, _doc.texts()) {
+				_stripTexts.append(text);
+			}
+		}
 
 		foreach(PhStripText * text, _doc.texts()) {
 
@@ -264,7 +271,7 @@ void PhGraphicStrip::draw(int x, int y, int width, int height, int tcOffset, QLi
 				// FIXME font and color not implemented
 				//PhGraphicText gText(&_textFont, text->content());
 				//gText.setColor(computeColor(text->people(), selectedPeoples, invertedColor));
-				_stripTexts.append(text);
+				//_stripTexts.append(text);
 			}
 
 			PhPeople * people = text->people();

--- a/libs/PhGraphicStrip/PhGraphicStrip.cpp
+++ b/libs/PhGraphicStrip/PhGraphicStrip.cpp
@@ -255,14 +255,7 @@ void PhGraphicStrip::draw(int x, int y, int width, int height, int tcOffset, QLi
 
 		// housekeeping !
 		_nextPeoples.clear();
-		//_stripTexts.clear();
-
-		// append all strip texts !
-		if (_stripTexts.empty() && !_doc.texts().empty()) {
-			foreach(PhStripText * text, _doc.texts()) {
-				_stripTexts.append(text);
-			}
-		}
+		_stripTexts.clear();
 
 		foreach(PhStripText * text, _doc.texts()) {
 
@@ -271,7 +264,7 @@ void PhGraphicStrip::draw(int x, int y, int width, int height, int tcOffset, QLi
 				// FIXME font and color not implemented
 				//PhGraphicText gText(&_textFont, text->content());
 				//gText.setColor(computeColor(text->people(), selectedPeoples, invertedColor));
-				//_stripTexts.append(text);
+				_stripTexts.append(text);
 			}
 
 			PhPeople * people = text->people();

--- a/libs/PhGraphicStrip/PhGraphicStrip.cpp
+++ b/libs/PhGraphicStrip/PhGraphicStrip.cpp
@@ -255,22 +255,16 @@ void PhGraphicStrip::draw(int x, int y, int width, int height, int tcOffset, QLi
 
 		// housekeeping !
 		_nextPeoples.clear();
+		_stripTexts.clear();
 
 		foreach(PhStripText * text, _doc.texts()) {
 
 			if( !((text->timeOut() < timeIn) || (text->timeIn() > timeOut)) ) {
 				counter++;
-				PhGraphicText gText(&_textFont, text->content());
-				gText.setZ(-1);
-
-				gText.setX(x + text->timeIn() / timePerPixel - offset);
-				gText.setWidth((text->timeOut() - text->timeIn()) / timePerPixel);
-				gText.setY(y + text->y() * height);
-				gText.setHeight(text->height() * height);
-				gText.setZ(-1);
-				gText.setColor(computeColor(text->people(), selectedPeoples, invertedColor));
-
-				gText.draw();
+				// FIXME font and color not implemented
+				//PhGraphicText gText(&_textFont, text->content());
+				//gText.setColor(computeColor(text->people(), selectedPeoples, invertedColor));
+				_stripTexts.append(text);
 			}
 
 			PhPeople * people = text->people();

--- a/libs/PhGraphicStrip/PhGraphicStrip.cpp
+++ b/libs/PhGraphicStrip/PhGraphicStrip.cpp
@@ -284,13 +284,6 @@ void PhGraphicStrip::draw(int x, int y, int width, int height, int tcOffset, QLi
 			backgroundRect.draw();
 		}
 
-		PhGraphicSolidRect syncBarRect;
-		syncBarRect.setColor(QColor(225, 86, 108));
-		syncBarRect.setSize(4, height);
-		syncBarRect.setPosition(x + width/6, y, 0);
-
-		syncBarRect.draw();
-
 		if(_settings->displayRuler()) {
 			PhTime rulerTimeIn = _settings->rulerTimeIn();
 			PhTime timeBetweenRuler = _settings->timeBetweenRuler();

--- a/libs/PhGraphicStrip/PhGraphicStrip.cpp
+++ b/libs/PhGraphicStrip/PhGraphicStrip.cpp
@@ -85,6 +85,15 @@ void PhGraphicStrip::onDocChanged()
 		previousCutTime = cut->timeIn();
 	}
 
+	// loops
+	_loopModel.clear();
+	int previousLoopTime = 0;
+	foreach(PhStripLoop * loop, _doc.loops()) {
+		PhNextPeople *loopPeople = new PhNextPeople(loop->label(), "", previousLoopTime, true, loop->timeIn() - previousLoopTime);
+		_loopModel.addNextPeople(loopPeople);
+		previousLoopTime = loop->timeIn();
+	}
+
 	// strip texts
 	_stripTextModelTrack0.clear();
 	_stripTextModelTrack1.clear();
@@ -402,33 +411,7 @@ void PhGraphicStrip::draw(int x, int y, int width, int height, int tcOffset, QLi
 		}
 
 		foreach(PhStripLoop * loop, _doc.loops()) {
-			//_counter++;
-			// This calcul allow the cross to come smoothly on the screen (height * timePerPixel / 8)
-			if( ((loop->timeIn() + height * timePerPixel / 8) > timeIn) && ((loop->timeIn() - height * timePerPixel / 8 ) < timeOut)) {
-				PhGraphicLoop gLoop;
-				if(!invertedColor)
-					gLoop.setColor(Qt::black);
-				else
-					gLoop.setColor(Qt::white);
-
-				int xLoop = x + loop->timeIn() / timePerPixel - offset;
-				gLoop.setX(xLoop);
-				gLoop.setY(y);
-				gLoop.setZ(-1);
-				gLoop.setThickness(height / 40);
-				gLoop.setHeight(height);
-				gLoop.setCrossSize(height / 4);
-				gLoop.setWidth(height / 4);
-
-				gLoop.draw();
-
-				PhGraphicText gLabel(&_hudFont, loop->label(), xLoop + 10, y + height * 3 / 4, -1);
-				gLabel.setWidth(_hudFont.getNominalWidth(loop->label()));
-				gLabel.setHeight(height / 4);
-				gLabel.setColor(Qt::gray);
-				gLabel.draw();
-			}
-
+			// loop in the next people part
 			if(displayNextText && ((loop->timeIn() + height * timePerPixel / 8) > timeIn)) {
 				PhGraphicLoop gLoopPred;
 

--- a/libs/PhGraphicStrip/PhGraphicStrip.cpp
+++ b/libs/PhGraphicStrip/PhGraphicStrip.cpp
@@ -410,31 +410,6 @@ void PhGraphicStrip::draw(int x, int y, int width, int height, int tcOffset, QLi
 				break;
 		}
 
-		foreach(PhStripLoop * loop, _doc.loops()) {
-			// loop in the next people part
-			if(displayNextText && ((loop->timeIn() + height * timePerPixel / 8) > timeIn)) {
-				PhGraphicLoop gLoopPred;
-
-				int howFarIsLoop = (loop->timeIn() - clockTime) / verticalTimePerPixel;
-				gLoopPred.setColor(Qt::white);
-
-				gLoopPred.setHorizontalLoop(true);
-				gLoopPred.setZ(-3);
-
-				gLoopPred.setX(width - width / 10);
-				gLoopPred.setY(y - howFarIsLoop);
-				gLoopPred.setHeight(30);
-
-				gLoopPred.setThickness(3);
-				gLoopPred.setCrossSize(20);
-				gLoopPred.setWidth(width / 10);
-
-				gLoopPred.draw();
-			}
-			if((loop->timeIn() - height * timePerPixel / 8) > timeOut + 25 * 30)
-				break;
-		}
-
 		foreach(PhStripDetect * detect, _doc.detects()) {
 			//_counter++;
 

--- a/libs/PhGraphicStrip/PhGraphicStrip.cpp
+++ b/libs/PhGraphicStrip/PhGraphicStrip.cpp
@@ -168,6 +168,87 @@ void PhGraphicStrip::onDocChanged()
 			previousTimeOutTrack3 = text->timeOut();
 		}
 	}
+
+	// strip text people
+	_stripPeopleModelTrack0.clear();
+	_stripPeopleModelTrack1.clear();
+	_stripPeopleModelTrack2.clear();
+	_stripPeopleModelTrack3.clear();
+	previousTimeOutTrack0 = 0;
+	previousTimeOutTrack1 = 0;
+	previousTimeOutTrack2 = 0;
+	previousTimeOutTrack3 = 0;
+
+	foreach(PhStripText * text, _doc.texts()) {
+		PhStripText *peopleText = new PhStripText(text->timeIn(),
+												  text->people(),
+												  text->timeOut(),
+												  0,
+												  "", //empty content
+												  0, //height
+												  true);
+
+		if (text->y() == 0) {
+			PhStripText *emptyText = new PhStripText(previousTimeOutTrack0,
+													 text->people(),
+													 text->timeIn(),
+													 0,
+													 text->people()->name(),
+													 0, //height
+													 selectedPeoples.size()==0 || selectedPeoples.contains(text->people()));
+
+			_stripPeopleModelTrack0.addStripText(emptyText);
+			_stripPeopleModelTrack0.addStripText(peopleText);
+
+			previousTimeOutTrack0 = text->timeOut();
+		}
+
+		if (text->y() == 0.25) {
+			PhStripText *emptyText = new PhStripText(previousTimeOutTrack1,
+													 text->people(),
+													 text->timeIn(),
+													 0,
+													 text->people()->name(),
+													 0, //height
+													 selectedPeoples.size()==0 || selectedPeoples.contains(text->people()));
+
+			_stripPeopleModelTrack1.addStripText(emptyText);
+			_stripPeopleModelTrack1.addStripText(peopleText);
+
+			previousTimeOutTrack1 = text->timeOut();
+		}
+
+		if (text->y() == 0.5) {
+			PhStripText *emptyText = new PhStripText(previousTimeOutTrack2,
+													 text->people(),
+													 text->timeIn(),
+													 0,
+													 text->people()->name(),
+													 0, //height
+													 selectedPeoples.size()==0 || selectedPeoples.contains(text->people()));
+
+			_stripPeopleModelTrack2.addStripText(emptyText);
+			_stripPeopleModelTrack2.addStripText(peopleText);
+
+			previousTimeOutTrack2 = text->timeOut();
+		}
+
+
+		if (text->y() == 0.75) {
+			PhStripText *emptyText = new PhStripText(previousTimeOutTrack3,
+													 text->people(),
+													 text->timeIn(),
+													 0,
+													 text->people()->name(),
+													 0, //height
+													 selectedPeoples.size()==0 || selectedPeoples.contains(text->people()));
+
+			_stripPeopleModelTrack3.addStripText(emptyText);
+			_stripPeopleModelTrack3.addStripText(peopleText);
+
+			previousTimeOutTrack3 = text->timeOut();
+		}
+	}
 }
 
 PhFont *PhGraphicStrip::getTextFont()
@@ -361,53 +442,6 @@ void PhGraphicStrip::draw(int x, int y, int width, int height, int tcOffset, QLi
 				rulerNumber++;
 				rulerTime += timeBetweenRuler;
 			}
-		}
-
-		int minTimeBetweenPeople = 48000;
-		int timeBetweenPeopleAndText = 4000;
-		QMap<float, PhStripText * > lastTextList;
-
-
-		int verticalTimePerPixel = _settings->verticalTimePerPixel();
-		bool displayNextText = _settings->displayNextText();
-		PhTime maxTimeIn = timeOut;
-		if(displayNextText)
-			maxTimeIn += y * verticalTimePerPixel;
-
-		foreach(PhStripText * text, _doc.texts()) {
-			PhPeople * people = text->people();
-			QString name = people ? people->name() : "???";
-			PhGraphicText gPeople(&_hudFont, name);
-			gPeople.setWidth(name.length() * 12);
-			gPeople.setHeight(text->height() * height / 2);
-			int x0 = x + (text->timeIn() - timeBetweenPeopleAndText) / timePerPixel - offset - gPeople.width();
-
-			PhStripText * lastText = lastTextList[text->y()];
-			// Display the people name only if one of the following condition is true:
-			// - it is the first text
-			// - it is a different people
-			// - the distance between the latest text and the current is superior to a limit
-			if( x0 < width
-			    && x0 + gPeople.width() > 0
-			    && (
-			        (lastText == NULL)
-			        || (lastText->people() != text->people())
-			        || (text->timeIn() - lastText->timeOut() > minTimeBetweenPeople))
-			    ) {
-
-				gPeople.setX(x0);
-				gPeople.setY(y + text->y() * height);
-				gPeople.setZ(-1);
-
-				gPeople.setColor(computeColor(people, selectedPeoples, invertedColor));
-
-				gPeople.draw();
-			}
-
-			lastTextList[text->y()] = text;
-
-			if(text->timeIn() > maxTimeIn)
-				break;
 		}
 
 		foreach(PhStripDetect * detect, _doc.detects()) {

--- a/libs/PhGraphicStrip/PhGraphicStrip.cpp
+++ b/libs/PhGraphicStrip/PhGraphicStrip.cpp
@@ -271,24 +271,15 @@ void PhGraphicStrip::draw(int x, int y, int width, int height, int tcOffset, QLi
 	_infos.clear();
 
 	int counter = 0;
-	bool invertedColor = _settings->invertColor();
 
 	int lastDrawElapsed = _testTimer.elapsed();
-	//PHDEBUG << "time " << _clock.time() << " \trate " << _clock.rate();
 
 	if(height > 0) {
-		int timePerPixel = _settings->horizontalTimePerPixel();
 		_textFont.setBoldness(_settings->textBoldness());
 		_textFont.setFontFile(_settings->textFontFile());
 
-		long syncBar_X_FromLeft = width / 6;
 		long delay = (int)(24 * _settings->screenDelay() *  _clock.rate());
 		PhTime clockTime = _clock.time() + delay;
-		long offset = clockTime / timePerPixel - syncBar_X_FromLeft;
-
-		//Compute the visible duration of the strip
-		PhTime stripDuration = width * timePerPixel;
-
 
 		if(_settings->stripTestMode()) {
 			foreach(PhStripCut * cut, _doc.cuts()) {
@@ -305,9 +296,6 @@ void PhGraphicStrip::draw(int x, int y, int width, int height, int tcOffset, QLi
 			return;
 		}
 
-		PhTime timeIn = clockTime - syncBar_X_FromLeft * timePerPixel;
-		PhTime timeOut = timeIn + stripDuration;
-
 
 //		if(_settings->displayBackground()) {
 //			//Draw backgroung picture
@@ -319,7 +307,7 @@ void PhGraphicStrip::draw(int x, int y, int width, int height, int tcOffset, QLi
 //				leftBG -= height - ((-offset) % height);
 
 //			PhGraphicTexturedRect* backgroundImage = &_backgroundImageLight;
-//			if(invertedColor)
+//			if(_settings->invertColor())
 //				backgroundImage = &_backgroundImageDark;
 
 //			backgroundImage->setX(x + leftBG);

--- a/libs/PhGraphicStrip/PhGraphicStrip.cpp
+++ b/libs/PhGraphicStrip/PhGraphicStrip.cpp
@@ -39,6 +39,19 @@ PhClock *PhGraphicStrip::clock()
 
 void PhGraphicStrip::onDocChanged()
 {
+	QList<PhPeople *> selectedPeoples;
+	bool invertedColor = _settings->invertColor();
+
+	_nextPeopleModel.clear();
+
+	foreach(PhStripText * text, _doc.texts()) {
+		PhPeople * people = text->people();
+		PhNextPeople *nextPeople = new PhNextPeople(people->name(),
+													computeColor(people, selectedPeoples, invertedColor).name(),
+													text->timeIn(),
+													selectedPeoples.size()==0 || selectedPeoples.contains(people));
+		_nextPeopleModel.addNextPeople(nextPeople);
+	}
 
 }
 
@@ -254,7 +267,7 @@ void PhGraphicStrip::draw(int x, int y, int width, int height, int tcOffset, QLi
 			maxTimeIn += y * verticalTimePerPixel;
 
 		// housekeeping !
-		_nextPeoples.clear();
+		//_nextPeoples.clear();
 		_stripTexts.clear();
 
 		foreach(PhStripText * text, _doc.texts()) {
@@ -296,18 +309,18 @@ void PhGraphicStrip::draw(int x, int y, int width, int height, int tcOffset, QLi
 				gPeople.draw();
 			}
 
-			if(displayNextText
-			   && text->timeIn() - clockTime > -50*verticalTimePerPixel // make sure the label does not disappear suddenly
-			   &&  text->timeIn() - clockTime < (y-tcOffset)*verticalTimePerPixel
-			   && ((lastText == NULL)
-			       || (lastText->people() != text->people())
-			       || (text->timeIn() - lastText->timeOut() > minTimeBetweenPeople))) {
-				PhNextPeople *nextPeople = new PhNextPeople(people->name(),
-															computeColor(people, selectedPeoples, invertedColor).name(),
-															text->timeIn(),
-															selectedPeoples.size()==0 || selectedPeoples.contains(people));
-				_nextPeoples.append(nextPeople);
-			}
+//			if(displayNextText
+//			   && text->timeIn() - clockTime > -50*verticalTimePerPixel // make sure the label does not disappear suddenly
+//			   &&  text->timeIn() - clockTime < (y-tcOffset)*verticalTimePerPixel
+//			   && ((lastText == NULL)
+//			       || (lastText->people() != text->people())
+//			       || (text->timeIn() - lastText->timeOut() > minTimeBetweenPeople))) {
+//				PhNextPeople *nextPeople = new PhNextPeople(people->name(),
+//															computeColor(people, selectedPeoples, invertedColor).name(),
+//															text->timeIn(),
+//															selectedPeoples.size()==0 || selectedPeoples.contains(people));
+//				_nextPeoples.append(nextPeople);
+//			}
 
 			lastTextList[text->y()] = text;
 

--- a/libs/PhGraphicStrip/PhGraphicStrip.cpp
+++ b/libs/PhGraphicStrip/PhGraphicStrip.cpp
@@ -162,6 +162,48 @@ void PhGraphicStrip::onDocChanged()
 			}
 		}
 
+		// off detects
+		previousTimeOut = 0;
+		foreach(PhStripDetect * detect, _doc.detects()) {
+			if (text->y() == y && detect->type() == PhStripDetect::Off) {
+				PhNextPeople *detectPeople = new PhNextPeople("", "", previousTimeOut, true, detect->timeIn() - previousTimeOut);
+				track->offDetectModel()->addNextPeople(detectPeople);
+				previousTimeOut = detect->timeIn();
+			}
+		}
+
+		// semi-off detects
+		previousTimeOut = 0;
+		foreach(PhStripDetect * detect, _doc.detects()) {
+			if (text->y() == y && detect->type() == PhStripDetect::SemiOff) {
+				PhNextPeople *detectPeople = new PhNextPeople("", "", previousTimeOut, true, detect->timeIn() - previousTimeOut);
+				track->semiOffDetectModel()->addNextPeople(detectPeople);
+				previousTimeOut = detect->timeIn();
+			}
+		}
+
+		// arrow-up detects
+		previousTimeOut = 0;
+		foreach(PhStripDetect * detect, _doc.detects()) {
+			if (text->y() == y && detect->type() == PhStripDetect::ArrowUp) {
+				PhNextPeople *detectPeople = new PhNextPeople("", "", previousTimeOut, true, detect->timeIn() - previousTimeOut);
+				track->arrowUpDetectModel()->addNextPeople(detectPeople);
+				previousTimeOut = detect->timeIn();
+			}
+		}
+
+		// arrow-down detects
+		previousTimeOut = 0;
+		foreach(PhStripDetect * detect, _doc.detects()) {
+			if (text->y() == y && detect->type() == PhStripDetect::ArrowDown) {
+				PhNextPeople *spacer = new PhNextPeople("spacer", "", previousTimeOut, true, detect->timeIn() - previousTimeOut);
+				PhNextPeople *detectPeople = new PhNextPeople("", "", detect->timeIn(), true, detect->timeOut() - detect->timeIn());
+				track->arrowDownDetectModel()->addNextPeople(spacer);
+				track->arrowDownDetectModel()->addNextPeople(detectPeople);
+				previousTimeOut = detect->timeOut();
+			}
+		}
+
 		_trackModel.addTrack(track);
 	}
 }
@@ -296,51 +338,6 @@ void PhGraphicStrip::draw(int x, int y, int width, int height, int tcOffset, QLi
 
 			backgroundRect.setZ(-2);
 			backgroundRect.draw();
-		}
-
-		foreach(PhStripDetect * detect, _doc.detects()) {
-			//_counter++;
-
-			if((timeIn < detect->timeOut()) && (detect->timeIn() < timeOut) ) {
-				PhGraphicRect *gDetect = NULL;
-				switch (detect->type()) {
-				case PhStripDetect::Off:
-					gDetect = new PhGraphicSolidRect();
-					gDetect->setY(y + detect->y() * height + detect->height() * height * 0.9);
-					gDetect->setHeight(detect->height() * height / 10);
-					break;
-				case PhStripDetect::SemiOff:
-					gDetect = new PhGraphicDashedLine((detect->timeOut() - detect->timeIn()) / 1200);
-					gDetect->setY(y + detect->y() * height + detect->height() * height * 0.9);
-					gDetect->setHeight(detect->height() * height / 10);
-					break;
-				case PhStripDetect::ArrowUp:
-					gDetect = new PhGraphicArrow(PhGraphicArrow::DownLeftToUpRight);
-					gDetect->setY(y + detect->y() * height);
-					gDetect->setHeight(detect->height() * height);
-					break;
-				case PhStripDetect::ArrowDown:
-					gDetect = new PhGraphicArrow(PhGraphicArrow::UpLefToDownRight);
-					gDetect->setY(y + detect->y() * height);
-					gDetect->setHeight(detect->height() * height);
-					break;
-				default:
-					break;
-				}
-
-				if(gDetect) {
-					gDetect->setColor(computeColor(detect->people(), selectedPeoples, invertedColor));
-
-					gDetect->setX(x + detect->timeIn() / timePerPixel - offset);
-					gDetect->setZ(-1);
-					gDetect->setWidth((detect->timeOut() - detect->timeIn()) / timePerPixel);
-					gDetect->draw();
-					delete gDetect;
-				}
-			}
-			//Doesn't need to process undisplayed content
-			if(detect->timeIn() > timeOut)
-				break;
 		}
 	}
 

--- a/libs/PhGraphicStrip/PhGraphicStrip.cpp
+++ b/libs/PhGraphicStrip/PhGraphicStrip.cpp
@@ -309,36 +309,36 @@ void PhGraphicStrip::draw(int x, int y, int width, int height, int tcOffset, QLi
 		PhTime timeOut = timeIn + stripDuration;
 
 
-		if(_settings->displayBackground()) {
-			//Draw backgroung picture
-			int n = width / height + 2; // compute how much background repetition do we need
-			long leftBG = 0;
-			if(offset >= 0)
-				leftBG -= offset % height;
-			else
-				leftBG -= height - ((-offset) % height);
+//		if(_settings->displayBackground()) {
+//			//Draw backgroung picture
+//			int n = width / height + 2; // compute how much background repetition do we need
+//			long leftBG = 0;
+//			if(offset >= 0)
+//				leftBG -= offset % height;
+//			else
+//				leftBG -= height - ((-offset) % height);
 
-			PhGraphicTexturedRect* backgroundImage = &_backgroundImageLight;
-			if(invertedColor)
-				backgroundImage = &_backgroundImageDark;
+//			PhGraphicTexturedRect* backgroundImage = &_backgroundImageLight;
+//			if(invertedColor)
+//				backgroundImage = &_backgroundImageDark;
 
-			backgroundImage->setX(x + leftBG);
-			backgroundImage->setY(y);
-			backgroundImage->setSize(height * n, height);
-			backgroundImage->setZ(-2);
-			backgroundImage->setTextureCoordinate(n, 1);
-			backgroundImage->draw();
-		}
-		else {
-			PhGraphicSolidRect backgroundRect(x, y, width, height);
-			if(_settings->invertColor())
-				backgroundRect.setColor(QColor(_settings->backgroundColorDark()));
-			else
-				backgroundRect.setColor(QColor(_settings->backgroundColorLight()));
+//			backgroundImage->setX(x + leftBG);
+//			backgroundImage->setY(y);
+//			backgroundImage->setSize(height * n, height);
+//			backgroundImage->setZ(-2);
+//			backgroundImage->setTextureCoordinate(n, 1);
+//			backgroundImage->draw();
+//		}
+//		else {
+//			PhGraphicSolidRect backgroundRect(x, y, width, height);
+//			if(_settings->invertColor())
+//				backgroundRect.setColor(QColor(_settings->backgroundColorDark()));
+//			else
+//				backgroundRect.setColor(QColor(_settings->backgroundColorLight()));
 
-			backgroundRect.setZ(-2);
-			backgroundRect.draw();
-		}
+//			backgroundRect.setZ(-2);
+//			backgroundRect.draw();
+//		}
 	}
 
 	//	PHDEBUG << "off counter : " << offCounter << "cut counter : " << cutCounter << "loop counter : " << loopCounter;

--- a/libs/PhGraphicStrip/PhGraphicStrip.cpp
+++ b/libs/PhGraphicStrip/PhGraphicStrip.cpp
@@ -107,160 +107,62 @@ void PhGraphicStrip::onDocChanged()
 		previousLoopTime = loop->timeIn();
 	}
 
-	// strip texts
-	_stripTextModelTrack0.clear();
-	_stripTextModelTrack1.clear();
-	_stripTextModelTrack2.clear();
-	_stripTextModelTrack3.clear();
-	int previousTimeOutTrack0 = 0;
-	int previousTimeOutTrack1 = 0;
-	int previousTimeOutTrack2 = 0;
-	int previousTimeOutTrack3 = 0;
+	QList<float> trackY;
+	trackY << 0 << 0.25 << 0.5 << 0.75;
 
-	foreach(PhStripText * text, _doc.texts()) {
-		text->setSelected(selectedPeoples.size()==0 || selectedPeoples.contains(text->people()));
+	foreach(float y, trackY) {
+		PhTrack * track = new PhTrack();
+		int previousTimeOut;
 
-		if (text->y() == 0) {
-			PhStripText *emptyText = new PhStripText(previousTimeOutTrack0,
-													 text->people(),
-													 text->timeIn(),
-													 0,
-													 "", // empty content
-													 0, //height
-													 true);
+		// strip texts
+		previousTimeOut = 0;
+		foreach(PhStripText * text, _doc.texts()) {
+			if (text->y() == y) {
+				text->setSelected(selectedPeoples.size()==0 || selectedPeoples.contains(text->people()));
 
-			_stripTextModelTrack0.addStripText(emptyText);
-			_stripTextModelTrack0.addStripText(text);
+				PhStripText *emptyText = new PhStripText(previousTimeOut,
+														 text->people(),
+														 text->timeIn(),
+														 0,
+														 "", // empty content
+														 0, //height
+														 true);
 
-			previousTimeOutTrack0 = text->timeOut();
+				track->stripTextModel()->addStripText(emptyText);
+				track->stripTextModel()->addStripText(text);
+
+				previousTimeOut = text->timeOut();
+			}
 		}
 
-		if (text->y() == 0.25) {
-			PhStripText *emptyText = new PhStripText(previousTimeOutTrack1,
-													 text->people(),
-													 text->timeIn(),
-													 0,
-													 "", // empty content
-													 0, //height
-													 true);
+		// strip text people
+		previousTimeOut = 0;
+		foreach(PhStripText * text, _doc.texts()) {
+			if (text->y() == y) {
+				PhStripText *peopleText = new PhStripText(previousTimeOut,
+														 text->people(),
+														 text->timeIn(),
+														 0,
+														 text->people()->name(),
+														 0, //height
+														 selectedPeoples.size()==0 || selectedPeoples.contains(text->people()));
 
-			_stripTextModelTrack1.addStripText(emptyText);
-			_stripTextModelTrack1.addStripText(text);
+				PhStripText *emptyText = new PhStripText(text->timeIn(),
+														  text->people(),
+														  text->timeOut(),
+														  0,
+														  "", //empty content
+														  0, //height
+														  true);
 
-			previousTimeOutTrack1 = text->timeOut();
+				track->stripPeopleModel()->addStripText(peopleText);
+				track->stripPeopleModel()->addStripText(emptyText);
+
+				previousTimeOut = text->timeOut();
+			}
 		}
 
-		if (text->y() == 0.5) {
-			PhStripText *emptyText = new PhStripText(previousTimeOutTrack2,
-													 text->people(),
-													 text->timeIn(),
-													 0,
-													 "", // empty content
-													 0, //height
-													 true);
-
-			_stripTextModelTrack2.addStripText(emptyText);
-			_stripTextModelTrack2.addStripText(text);
-
-			previousTimeOutTrack2 = text->timeOut();
-		}
-
-
-		if (text->y() == 0.75) {
-			PhStripText *emptyText = new PhStripText(previousTimeOutTrack3,
-													 text->people(),
-													 text->timeIn(),
-													 0,
-													 "", // empty content
-													 0, //height
-													 true);
-
-			_stripTextModelTrack3.addStripText(emptyText);
-			_stripTextModelTrack3.addStripText(text);
-
-			previousTimeOutTrack3 = text->timeOut();
-		}
-	}
-
-	// strip text people
-	_stripPeopleModelTrack0.clear();
-	_stripPeopleModelTrack1.clear();
-	_stripPeopleModelTrack2.clear();
-	_stripPeopleModelTrack3.clear();
-	previousTimeOutTrack0 = 0;
-	previousTimeOutTrack1 = 0;
-	previousTimeOutTrack2 = 0;
-	previousTimeOutTrack3 = 0;
-
-	foreach(PhStripText * text, _doc.texts()) {
-		PhStripText *peopleText = new PhStripText(text->timeIn(),
-												  text->people(),
-												  text->timeOut(),
-												  0,
-												  "", //empty content
-												  0, //height
-												  true);
-
-		if (text->y() == 0) {
-			PhStripText *emptyText = new PhStripText(previousTimeOutTrack0,
-													 text->people(),
-													 text->timeIn(),
-													 0,
-													 text->people()->name(),
-													 0, //height
-													 selectedPeoples.size()==0 || selectedPeoples.contains(text->people()));
-
-			_stripPeopleModelTrack0.addStripText(emptyText);
-			_stripPeopleModelTrack0.addStripText(peopleText);
-
-			previousTimeOutTrack0 = text->timeOut();
-		}
-
-		if (text->y() == 0.25) {
-			PhStripText *emptyText = new PhStripText(previousTimeOutTrack1,
-													 text->people(),
-													 text->timeIn(),
-													 0,
-													 text->people()->name(),
-													 0, //height
-													 selectedPeoples.size()==0 || selectedPeoples.contains(text->people()));
-
-			_stripPeopleModelTrack1.addStripText(emptyText);
-			_stripPeopleModelTrack1.addStripText(peopleText);
-
-			previousTimeOutTrack1 = text->timeOut();
-		}
-
-		if (text->y() == 0.5) {
-			PhStripText *emptyText = new PhStripText(previousTimeOutTrack2,
-													 text->people(),
-													 text->timeIn(),
-													 0,
-													 text->people()->name(),
-													 0, //height
-													 selectedPeoples.size()==0 || selectedPeoples.contains(text->people()));
-
-			_stripPeopleModelTrack2.addStripText(emptyText);
-			_stripPeopleModelTrack2.addStripText(peopleText);
-
-			previousTimeOutTrack2 = text->timeOut();
-		}
-
-
-		if (text->y() == 0.75) {
-			PhStripText *emptyText = new PhStripText(previousTimeOutTrack3,
-													 text->people(),
-													 text->timeIn(),
-													 0,
-													 text->people()->name(),
-													 0, //height
-													 selectedPeoples.size()==0 || selectedPeoples.contains(text->people()));
-
-			_stripPeopleModelTrack3.addStripText(emptyText);
-			_stripPeopleModelTrack3.addStripText(peopleText);
-
-			previousTimeOutTrack3 = text->timeOut();
-		}
+		_trackModel.addTrack(track);
 	}
 }
 

--- a/libs/PhGraphicStrip/PhGraphicStrip.cpp
+++ b/libs/PhGraphicStrip/PhGraphicStrip.cpp
@@ -253,6 +253,9 @@ void PhGraphicStrip::draw(int x, int y, int width, int height, int tcOffset, QLi
 		if(displayNextText)
 			maxTimeIn += y * verticalTimePerPixel;
 
+		// housekeeping !
+		_nextPeoples.clear();
+
 		foreach(PhStripText * text, _doc.texts()) {
 
 			if( !((text->timeOut() < timeIn) || (text->timeIn() > timeOut)) ) {
@@ -299,39 +302,17 @@ void PhGraphicStrip::draw(int x, int y, int width, int height, int tcOffset, QLi
 				gPeople.draw();
 			}
 
-			int howFarIsText = (text->timeIn() - clockTime) / verticalTimePerPixel;
-			PhTime timePerPeopleHeight = gPeople.height() * verticalTimePerPixel;
-			int y0 = y - howFarIsText - gPeople.height();
-
 			if(displayNextText
-			   && y0 < y
-			   && y0 > tcOffset
-			   && (timeIn < text->timeIn() + timePerPeopleHeight)
+			   && text->timeIn() - clockTime > -50*verticalTimePerPixel // make sure the label does not disappear suddenly
+			   &&  text->timeIn() - clockTime < (y-tcOffset)*verticalTimePerPixel
 			   && ((lastText == NULL)
 			       || (lastText->people() != text->people())
 			       || (text->timeIn() - lastText->timeOut() > minTimeBetweenPeople))) {
-				PhPeople * people = text->people();
-
-				//This line is used to see which text's name will be displayed
-				gPeople.setX(width - gPeople.width());
-				gPeople.setY(y0);
-				gPeople.setZ(-3);
-				gPeople.setHeight(text->height() * height / 2);
-
-				gPeople.setColor(computeColor(people, selectedPeoples, invertedColor));
-
-				PhGraphicSolidRect background(gPeople.x(), gPeople.y() - 2, gPeople.width(), gPeople.height() + 3);
-				if(selectedPeoples.size() && !selectedPeoples.contains(people))
-					background.setColor(QColor(90, 90, 90));
-				else
-					background.setColor(QColor(180, 180, 180));
-
-				background.setZ(gPeople.z() - 1);
-
-				if(!invertedColor)
-					background.draw();
-
-				gPeople.draw();
+				PhNextPeople *nextPeople = new PhNextPeople(people->name(),
+															computeColor(people, selectedPeoples, invertedColor).name(),
+															text->timeIn(),
+															selectedPeoples.size()==0 || selectedPeoples.contains(people));
+				_nextPeoples.append(nextPeople);
 			}
 
 			lastTextList[text->y()] = text;

--- a/libs/PhGraphicStrip/PhGraphicStrip.h
+++ b/libs/PhGraphicStrip/PhGraphicStrip.h
@@ -139,6 +139,10 @@ public:
 		return &_stripTextModelTrack3;
 	}
 
+	PhNextPeopleModel *rulerModel() {
+		return &_rulerModel;
+	}
+
 	PhNextPeopleModel *cutModel() {
 		return &_cutModel;
 	}
@@ -213,6 +217,7 @@ private:
 	PhStripTextModel _stripTextModelTrack1;
 	PhStripTextModel _stripTextModelTrack2;
 	PhStripTextModel _stripTextModelTrack3;
+	PhNextPeopleModel _rulerModel;
 	PhNextPeopleModel _cutModel;
 	PhNextPeopleModel _loopModel;
 	PhStripTextModel _stripPeopleModelTrack0;

--- a/libs/PhGraphicStrip/PhGraphicStrip.h
+++ b/libs/PhGraphicStrip/PhGraphicStrip.h
@@ -19,6 +19,7 @@
 #include "PhGraphic/PhGraphicSolidRect.h"
 #include "PhGraphic/PhGraphicLoop.h"
 #include "PhGraphicStrip/PhNextPeople.h"
+#include "PhGraphicStrip/PhNextPeopleModel.h"
 
 #include "PhSync/PhClock.h"
 
@@ -117,8 +118,8 @@ public:
 		return _infos;
 	}
 
-	QList<PhNextPeople*> nextPeoples() {
-		return _nextPeoples;
+	PhNextPeopleModel *nextPeopleModel() {
+		return &_nextPeopleModel;
 	}
 
 	QList<PhStripText*> stripTexts() {
@@ -170,7 +171,7 @@ private:
 
 	QStringList _infos;
 
-	QList<PhNextPeople*> _nextPeoples;
+	PhNextPeopleModel _nextPeopleModel;
 	QList<PhStripText *> _stripTexts;
 };
 

--- a/libs/PhGraphicStrip/PhGraphicStrip.h
+++ b/libs/PhGraphicStrip/PhGraphicStrip.h
@@ -18,6 +18,7 @@
 #include "PhGraphic/PhGraphicImage.h"
 #include "PhGraphic/PhGraphicSolidRect.h"
 #include "PhGraphic/PhGraphicLoop.h"
+#include "PhGraphicStrip/PhNextPeople.h"
 
 #include "PhSync/PhClock.h"
 
@@ -116,6 +117,10 @@ public:
 		return _infos;
 	}
 
+	QList<PhNextPeople*> nextPeoples() {
+		return _nextPeoples;
+	}
+
 private slots:
 	/**
 	 * @brief Clear all the graphic strip object related to the PhStripDoc.
@@ -160,6 +165,8 @@ private:
 	QColor computeColor(PhPeople *people, QList<PhPeople *> selectedPeoples, bool invertColor);
 
 	QStringList _infos;
+
+	QList<PhNextPeople*> _nextPeoples;
 };
 
 #endif // PHGRAPHICSTRIP_H

--- a/libs/PhGraphicStrip/PhGraphicStrip.h
+++ b/libs/PhGraphicStrip/PhGraphicStrip.h
@@ -147,6 +147,22 @@ public:
 		return &_loopModel;
 	}
 
+	PhStripTextModel *stripPeopleModelTrack0() {
+		return &_stripPeopleModelTrack0;
+	}
+
+	PhStripTextModel *stripPeopleModelTrack1() {
+		return &_stripPeopleModelTrack1;
+	}
+
+	PhStripTextModel *stripPeopleModelTrack2() {
+		return &_stripPeopleModelTrack2;
+	}
+
+	PhStripTextModel *stripPeopleModelTrack3() {
+		return &_stripPeopleModelTrack3;
+	}
+
 private slots:
 	/**
 	 * @brief Clear all the graphic strip object related to the PhStripDoc.
@@ -199,6 +215,10 @@ private:
 	PhStripTextModel _stripTextModelTrack3;
 	PhNextPeopleModel _cutModel;
 	PhNextPeopleModel _loopModel;
+	PhStripTextModel _stripPeopleModelTrack0;
+	PhStripTextModel _stripPeopleModelTrack1;
+	PhStripTextModel _stripPeopleModelTrack2;
+	PhStripTextModel _stripPeopleModelTrack3;
 };
 
 #endif // PHGRAPHICSTRIP_H

--- a/libs/PhGraphicStrip/PhGraphicStrip.h
+++ b/libs/PhGraphicStrip/PhGraphicStrip.h
@@ -21,6 +21,7 @@
 #include "PhGraphicStrip/PhNextPeople.h"
 #include "PhGraphicStrip/PhNextPeopleModel.h"
 #include "PhGraphicStrip/PhStripTextModel.h"
+#include "PhGraphicStrip/PhTrackModel.h"
 
 #include "PhSync/PhClock.h"
 
@@ -123,22 +124,6 @@ public:
 		return &_nextPeopleModel;
 	}
 
-	PhStripTextModel *stripTextModelTrack0() {
-		return &_stripTextModelTrack0;
-	}
-
-	PhStripTextModel *stripTextModelTrack1() {
-		return &_stripTextModelTrack1;
-	}
-
-	PhStripTextModel *stripTextModelTrack2() {
-		return &_stripTextModelTrack2;
-	}
-
-	PhStripTextModel *stripTextModelTrack3() {
-		return &_stripTextModelTrack3;
-	}
-
 	PhNextPeopleModel *rulerModel() {
 		return &_rulerModel;
 	}
@@ -151,20 +136,8 @@ public:
 		return &_loopModel;
 	}
 
-	PhStripTextModel *stripPeopleModelTrack0() {
-		return &_stripPeopleModelTrack0;
-	}
-
-	PhStripTextModel *stripPeopleModelTrack1() {
-		return &_stripPeopleModelTrack1;
-	}
-
-	PhStripTextModel *stripPeopleModelTrack2() {
-		return &_stripPeopleModelTrack2;
-	}
-
-	PhStripTextModel *stripPeopleModelTrack3() {
-		return &_stripPeopleModelTrack3;
+	PhTrackModel *trackModel() {
+		return &_trackModel;
 	}
 
 private slots:
@@ -213,17 +186,10 @@ private:
 	QStringList _infos;
 
 	PhNextPeopleModel _nextPeopleModel;
-	PhStripTextModel _stripTextModelTrack0;
-	PhStripTextModel _stripTextModelTrack1;
-	PhStripTextModel _stripTextModelTrack2;
-	PhStripTextModel _stripTextModelTrack3;
 	PhNextPeopleModel _rulerModel;
 	PhNextPeopleModel _cutModel;
 	PhNextPeopleModel _loopModel;
-	PhStripTextModel _stripPeopleModelTrack0;
-	PhStripTextModel _stripPeopleModelTrack1;
-	PhStripTextModel _stripPeopleModelTrack2;
-	PhStripTextModel _stripPeopleModelTrack3;
+	PhTrackModel _trackModel;
 };
 
 #endif // PHGRAPHICSTRIP_H

--- a/libs/PhGraphicStrip/PhGraphicStrip.h
+++ b/libs/PhGraphicStrip/PhGraphicStrip.h
@@ -143,6 +143,9 @@ public:
 		return &_cutModel;
 	}
 
+	PhNextPeopleModel *loopModel() {
+		return &_loopModel;
+	}
 
 private slots:
 	/**
@@ -195,6 +198,7 @@ private:
 	PhStripTextModel _stripTextModelTrack2;
 	PhStripTextModel _stripTextModelTrack3;
 	PhNextPeopleModel _cutModel;
+	PhNextPeopleModel _loopModel;
 };
 
 #endif // PHGRAPHICSTRIP_H

--- a/libs/PhGraphicStrip/PhGraphicStrip.h
+++ b/libs/PhGraphicStrip/PhGraphicStrip.h
@@ -20,6 +20,7 @@
 #include "PhGraphic/PhGraphicLoop.h"
 #include "PhGraphicStrip/PhNextPeople.h"
 #include "PhGraphicStrip/PhNextPeopleModel.h"
+#include "PhGraphicStrip/PhStripTextModel.h"
 
 #include "PhSync/PhClock.h"
 
@@ -122,8 +123,20 @@ public:
 		return &_nextPeopleModel;
 	}
 
-	QList<PhStripText*> stripTexts() {
-		return _stripTexts;
+	PhStripTextModel *stripTextModelTrack0() {
+		return &_stripTextModelTrack0;
+	}
+
+	PhStripTextModel *stripTextModelTrack1() {
+		return &_stripTextModelTrack1;
+	}
+
+	PhStripTextModel *stripTextModelTrack2() {
+		return &_stripTextModelTrack2;
+	}
+
+	PhStripTextModel *stripTextModelTrack3() {
+		return &_stripTextModelTrack3;
 	}
 
 private slots:
@@ -172,7 +185,10 @@ private:
 	QStringList _infos;
 
 	PhNextPeopleModel _nextPeopleModel;
-	QList<PhStripText *> _stripTexts;
+	PhStripTextModel _stripTextModelTrack0;
+	PhStripTextModel _stripTextModelTrack1;
+	PhStripTextModel _stripTextModelTrack2;
+	PhStripTextModel _stripTextModelTrack3;
 };
 
 #endif // PHGRAPHICSTRIP_H

--- a/libs/PhGraphicStrip/PhGraphicStrip.h
+++ b/libs/PhGraphicStrip/PhGraphicStrip.h
@@ -139,6 +139,11 @@ public:
 		return &_stripTextModelTrack3;
 	}
 
+	PhNextPeopleModel *cutModel() {
+		return &_cutModel;
+	}
+
+
 private slots:
 	/**
 	 * @brief Clear all the graphic strip object related to the PhStripDoc.
@@ -189,6 +194,7 @@ private:
 	PhStripTextModel _stripTextModelTrack1;
 	PhStripTextModel _stripTextModelTrack2;
 	PhStripTextModel _stripTextModelTrack3;
+	PhNextPeopleModel _cutModel;
 };
 
 #endif // PHGRAPHICSTRIP_H

--- a/libs/PhGraphicStrip/PhGraphicStrip.h
+++ b/libs/PhGraphicStrip/PhGraphicStrip.h
@@ -121,6 +121,10 @@ public:
 		return _nextPeoples;
 	}
 
+	QList<PhStripText*> stripTexts() {
+		return _stripTexts;
+	}
+
 private slots:
 	/**
 	 * @brief Clear all the graphic strip object related to the PhStripDoc.
@@ -167,6 +171,7 @@ private:
 	QStringList _infos;
 
 	QList<PhNextPeople*> _nextPeoples;
+	QList<PhStripText *> _stripTexts;
 };
 
 #endif // PHGRAPHICSTRIP_H

--- a/libs/PhGraphicStrip/PhGraphicStrip.pri
+++ b/libs/PhGraphicStrip/PhGraphicStrip.pri
@@ -7,10 +7,12 @@ HEADERS += \
 	../../libs/PhGraphicStrip/PhGraphicStrip.h \
 	../../libs/PhGraphicStrip/PhGraphicStripSettings.h \
     $$PWD/PhNextPeople.h \
-    $$PWD/PhNextPeopleModel.h
+    $$PWD/PhNextPeopleModel.h \
+    $$PWD/PhStripTextModel.h
 
 SOURCES += \
 	../../libs/PhGraphicStrip/PhGraphicStrip.cpp \
     $$PWD/PhNextPeople.cpp \
-    $$PWD/PhNextPeopleModel.cpp
+    $$PWD/PhNextPeopleModel.cpp \
+    $$PWD/PhStripTextModel.cpp
 

--- a/libs/PhGraphicStrip/PhGraphicStrip.pri
+++ b/libs/PhGraphicStrip/PhGraphicStrip.pri
@@ -8,11 +8,15 @@ HEADERS += \
 	../../libs/PhGraphicStrip/PhGraphicStripSettings.h \
     $$PWD/PhNextPeople.h \
     $$PWD/PhNextPeopleModel.h \
-    $$PWD/PhStripTextModel.h
+    $$PWD/PhStripTextModel.h \
+	$$PWD/PhTrack.h \
+	$$PWD/PhTrackModel.h
 
 SOURCES += \
 	../../libs/PhGraphicStrip/PhGraphicStrip.cpp \
     $$PWD/PhNextPeople.cpp \
     $$PWD/PhNextPeopleModel.cpp \
-    $$PWD/PhStripTextModel.cpp
+    $$PWD/PhStripTextModel.cpp \
+    $$PWD/PhTrack.cpp \
+    $$PWD/PhTrackModel.cpp
 

--- a/libs/PhGraphicStrip/PhGraphicStrip.pri
+++ b/libs/PhGraphicStrip/PhGraphicStrip.pri
@@ -5,8 +5,10 @@
 
 HEADERS += \
 	../../libs/PhGraphicStrip/PhGraphicStrip.h \
-	../../libs/PhGraphicStrip/PhGraphicStripSettings.h
+	../../libs/PhGraphicStrip/PhGraphicStripSettings.h \
+    $$PWD/PhNextPeople.h
 
 SOURCES += \
-	../../libs/PhGraphicStrip/PhGraphicStrip.cpp
+	../../libs/PhGraphicStrip/PhGraphicStrip.cpp \
+    $$PWD/PhNextPeople.cpp
 

--- a/libs/PhGraphicStrip/PhGraphicStrip.pri
+++ b/libs/PhGraphicStrip/PhGraphicStrip.pri
@@ -6,9 +6,11 @@
 HEADERS += \
 	../../libs/PhGraphicStrip/PhGraphicStrip.h \
 	../../libs/PhGraphicStrip/PhGraphicStripSettings.h \
-    $$PWD/PhNextPeople.h
+    $$PWD/PhNextPeople.h \
+    $$PWD/PhNextPeopleModel.h
 
 SOURCES += \
 	../../libs/PhGraphicStrip/PhGraphicStrip.cpp \
-    $$PWD/PhNextPeople.cpp
+    $$PWD/PhNextPeople.cpp \
+    $$PWD/PhNextPeopleModel.cpp
 

--- a/libs/PhGraphicStrip/PhNextPeople.cpp
+++ b/libs/PhGraphicStrip/PhNextPeople.cpp
@@ -1,0 +1,34 @@
+#include "PhGraphicStrip/PhNextPeople.h"
+
+PhNextPeople::PhNextPeople(QString name, QString color, PhTime timeIn, bool selected)
+ : PhPeople(name, color),
+   _timeIn(timeIn),
+   _selected(selected)
+{
+}
+
+PhTime PhNextPeople::timeIn()
+{
+	return _timeIn;
+}
+
+void PhNextPeople::setTimeIn(PhTime timeIn)
+{
+	if (timeIn != _timeIn) {
+		_timeIn = timeIn;
+		emit timeInChanged();
+	}
+}
+
+bool PhNextPeople::selected()
+{
+	return _selected;
+}
+
+void PhNextPeople::setSelected(bool selected)
+{
+	if (selected != _selected) {
+		_selected = selected;
+		emit selectedChanged();
+	}
+}

--- a/libs/PhGraphicStrip/PhNextPeople.cpp
+++ b/libs/PhGraphicStrip/PhNextPeople.cpp
@@ -7,7 +7,7 @@ PhNextPeople::PhNextPeople(QString name, QString color, PhTime timeIn, bool sele
 {
 }
 
-PhTime PhNextPeople::timeIn()
+PhTime PhNextPeople::timeIn() const
 {
 	return _timeIn;
 }
@@ -20,7 +20,7 @@ void PhNextPeople::setTimeIn(PhTime timeIn)
 	}
 }
 
-bool PhNextPeople::selected()
+bool PhNextPeople::selected() const
 {
 	return _selected;
 }

--- a/libs/PhGraphicStrip/PhNextPeople.cpp
+++ b/libs/PhGraphicStrip/PhNextPeople.cpp
@@ -1,9 +1,10 @@
 #include "PhGraphicStrip/PhNextPeople.h"
 
-PhNextPeople::PhNextPeople(QString name, QString color, PhTime timeIn, bool selected)
+PhNextPeople::PhNextPeople(QString name, QString color, PhTime timeIn, bool selected, PhTime duration)
  : PhPeople(name, color),
    _timeIn(timeIn),
-   _selected(selected)
+   _selected(selected),
+   _duration(duration)
 {
 }
 
@@ -17,6 +18,19 @@ void PhNextPeople::setTimeIn(PhTime timeIn)
 	if (timeIn != _timeIn) {
 		_timeIn = timeIn;
 		emit timeInChanged();
+	}
+}
+
+PhTime PhNextPeople::duration() const
+{
+	return _duration;
+}
+
+void PhNextPeople::setDuration(PhTime duration)
+{
+	if (duration != _duration) {
+		_duration = duration;
+		emit durationChanged();
 	}
 }
 

--- a/libs/PhGraphicStrip/PhNextPeople.h
+++ b/libs/PhGraphicStrip/PhNextPeople.h
@@ -9,6 +9,7 @@ class PhNextPeople : public PhPeople
 	Q_OBJECT
 	Q_PROPERTY(PhTime timeIn READ timeIn WRITE setTimeIn NOTIFY timeInChanged)
 	Q_PROPERTY(bool selected READ selected WRITE setSelected NOTIFY selectedChanged)
+	Q_PROPERTY(PhTime duration READ duration WRITE setDuration NOTIFY durationChanged)
 
 public:
    /*
@@ -16,7 +17,7 @@ public:
 	* @param name
 	* @param color
 	*/
-   PhNextPeople(QString name = "???", QString color = "#000000", PhTime timeIn = 0, bool selected = true);
+   PhNextPeople(QString name = "???", QString color = "#000000", PhTime timeIn = 0, bool selected = true, PhTime duration = 0);
 
 	/**
 	 * @brief Get the time in
@@ -28,6 +29,16 @@ public:
 	 * @param timeIn a PhTime
 	 */
 	void setTimeIn(PhTime timeIn);
+	/**
+	 * @brief Get the duration
+	 * @return a PhTime
+	 */
+	PhTime duration() const;
+	/**
+	 * @brief Set the duration
+	 * @param duration a PhTime
+	 */
+	void setDuration(PhTime duration);
 	/**
 	 * @brief Get whether this person is selected
 	 * @return a bool
@@ -42,10 +53,12 @@ public:
 signals:
 	void timeInChanged();
 	void selectedChanged();
+	void durationChanged();
 
 private:
 	PhTime _timeIn;
 	bool _selected;
+	PhTime _duration;
 };
 
 #endif // PHNEXTPEOPLE_H

--- a/libs/PhGraphicStrip/PhNextPeople.h
+++ b/libs/PhGraphicStrip/PhNextPeople.h
@@ -22,7 +22,7 @@ public:
 	 * @brief Get the time in
 	 * @return a PhTime
 	 */
-	PhTime timeIn();
+	PhTime timeIn() const;
 	/**
 	 * @brief Set the time in
 	 * @param timeIn a PhTime
@@ -32,7 +32,7 @@ public:
 	 * @brief Get whether this person is selected
 	 * @return a bool
 	 */
-	bool selected();
+	bool selected() const;
 	/**
 	 * @brief Set whether this person is selected
 	 * @param selected a bool

--- a/libs/PhGraphicStrip/PhNextPeople.h
+++ b/libs/PhGraphicStrip/PhNextPeople.h
@@ -1,0 +1,51 @@
+#ifndef PHNEXTPEOPLE_H
+#define PHNEXTPEOPLE_H
+
+#include "PhStrip/PhPeople.h"
+#include "PhSync/PhTime.h"
+
+class PhNextPeople : public PhPeople
+{
+	Q_OBJECT
+	Q_PROPERTY(PhTime timeIn READ timeIn WRITE setTimeIn NOTIFY timeInChanged)
+	Q_PROPERTY(bool selected READ selected WRITE setSelected NOTIFY selectedChanged)
+
+public:
+   /*
+	* @brief PhNextPeople
+	* @param name
+	* @param color
+	*/
+   PhNextPeople(QString name = "???", QString color = "#000000", PhTime timeIn = 0, bool selected = true);
+
+	/**
+	 * @brief Get the time in
+	 * @return a PhTime
+	 */
+	PhTime timeIn();
+	/**
+	 * @brief Set the time in
+	 * @param timeIn a PhTime
+	 */
+	void setTimeIn(PhTime timeIn);
+	/**
+	 * @brief Get whether this person is selected
+	 * @return a bool
+	 */
+	bool selected();
+	/**
+	 * @brief Set whether this person is selected
+	 * @param selected a bool
+	 */
+	void setSelected(bool selected);
+
+signals:
+	void timeInChanged();
+	void selectedChanged();
+
+private:
+	PhTime _timeIn;
+	bool _selected;
+};
+
+#endif // PHNEXTPEOPLE_H

--- a/libs/PhGraphicStrip/PhNextPeopleModel.cpp
+++ b/libs/PhGraphicStrip/PhNextPeopleModel.cpp
@@ -1,0 +1,49 @@
+#include "PhNextPeopleModel.h"
+
+PhNextPeopleModel::PhNextPeopleModel(QObject *parent) :
+	QAbstractListModel(parent)
+{
+}
+
+void PhNextPeopleModel::addNextPeople(const PhNextPeople *nextPeople)
+{
+	beginInsertRows(QModelIndex(), rowCount(), rowCount());
+	_nextPeoples << nextPeople;
+	endInsertRows();
+}
+
+int PhNextPeopleModel::rowCount(const QModelIndex & parent) const {
+	return _nextPeoples.count();
+}
+
+QVariant PhNextPeopleModel::data(const QModelIndex & index, int role) const {
+	if (index.row() < 0 || index.row() >= _nextPeoples.count())
+		return QVariant();
+	const PhNextPeople *nextPeople = _nextPeoples[index.row()];
+	if (role == NameRole)
+		return nextPeople->name();
+	else if (role == ColorRole)
+		return nextPeople->color();
+	else if (role == TimeInRole)
+		return nextPeople->timeIn();
+	else if (role == SelectedRole)
+		return nextPeople->selected();
+	return QVariant();
+}
+
+QHash<int, QByteArray> PhNextPeopleModel::roleNames() const {
+	QHash<int, QByteArray> roles;
+	roles[NameRole] = "name";
+	roles[ColorRole] = "color";
+	roles[TimeInRole] = "timeIn";
+	roles[SelectedRole] = "selected";
+	return roles;
+}
+
+void PhNextPeopleModel::clear() {
+	// delete ?
+	beginRemoveRows(QModelIndex(), 0, rowCount());
+	qDeleteAll(_nextPeoples);
+	_nextPeoples.clear();
+	endRemoveRows();
+}

--- a/libs/PhGraphicStrip/PhNextPeopleModel.cpp
+++ b/libs/PhGraphicStrip/PhNextPeopleModel.cpp
@@ -28,6 +28,8 @@ QVariant PhNextPeopleModel::data(const QModelIndex & index, int role) const {
 		return nextPeople->timeIn();
 	else if (role == SelectedRole)
 		return nextPeople->selected();
+	else if (role == DurationRole)
+		return nextPeople->duration();
 	return QVariant();
 }
 
@@ -37,11 +39,11 @@ QHash<int, QByteArray> PhNextPeopleModel::roleNames() const {
 	roles[ColorRole] = "color";
 	roles[TimeInRole] = "timeIn";
 	roles[SelectedRole] = "selected";
+	roles[DurationRole] = "duration";
 	return roles;
 }
 
 void PhNextPeopleModel::clear() {
-	// delete ?
 	beginRemoveRows(QModelIndex(), 0, rowCount());
 	qDeleteAll(_nextPeoples);
 	_nextPeoples.clear();

--- a/libs/PhGraphicStrip/PhNextPeopleModel.h
+++ b/libs/PhGraphicStrip/PhNextPeopleModel.h
@@ -12,7 +12,8 @@ public:
 		NameRole = Qt::UserRole + 1,
 		ColorRole,
 		TimeInRole,
-		SelectedRole
+		SelectedRole,
+		DurationRole
 	};
 
 	PhNextPeopleModel(QObject *parent = 0);

--- a/libs/PhGraphicStrip/PhNextPeopleModel.h
+++ b/libs/PhGraphicStrip/PhNextPeopleModel.h
@@ -1,0 +1,32 @@
+#ifndef PHNEXTPEOPLEMODEL_H
+#define PHNEXTPEOPLEMODEL_H
+
+#include <QAbstractListModel>
+#include "PhGraphicStrip/PhNextPeople.h"
+
+class PhNextPeopleModel : public QAbstractListModel
+{
+	Q_OBJECT
+public:
+	enum NextPeopleRoles {
+		NameRole = Qt::UserRole + 1,
+		ColorRole,
+		TimeInRole,
+		SelectedRole
+	};
+
+	PhNextPeopleModel(QObject *parent = 0);
+
+	void addNextPeople(const PhNextPeople *people);
+	int rowCount(const QModelIndex & parent = QModelIndex()) const;
+	QVariant data(const QModelIndex & index, int role = Qt::DisplayRole) const;
+	void clear();
+
+protected:
+	QHash<int, QByteArray> roleNames() const;
+
+private:
+	QList<const PhNextPeople*> _nextPeoples;
+};
+
+#endif // PHNEXTPEOPLEMODEL_H

--- a/libs/PhGraphicStrip/PhStripTextModel.cpp
+++ b/libs/PhGraphicStrip/PhStripTextModel.cpp
@@ -1,0 +1,51 @@
+#include "PhStripTextModel.h"
+
+PhStripTextModel::PhStripTextModel(QObject *parent) :
+	QAbstractListModel(parent)
+{
+}
+
+void PhStripTextModel::addStripText(const PhStripText *stripText)
+{
+	beginInsertRows(QModelIndex(), rowCount(), rowCount());
+	_stripTexts << stripText;
+	endInsertRows();
+}
+
+int PhStripTextModel::rowCount(const QModelIndex & parent) const {
+	return _stripTexts.count();
+}
+
+QVariant PhStripTextModel::data(const QModelIndex & index, int role) const {
+	if (index.row() < 0 || index.row() >= _stripTexts.count())
+		return QVariant();
+	const PhStripText *stripText = _stripTexts[index.row()];
+	if (role == ContentRole)
+		return stripText->content();
+	//else if (role == ColorRole)
+	//	return stripText->color();
+	else if (role == TimeInRole)
+		return stripText->timeIn();
+	else if (role == SelectedRole)
+		return stripText->selected();
+	else if (role == TimeOutRole)
+		return stripText->timeOut();
+	return QVariant();
+}
+
+QHash<int, QByteArray> PhStripTextModel::roleNames() const {
+	QHash<int, QByteArray> roles;
+	roles[ContentRole] = "content";
+	//roles[ColorRole] = "color";
+	roles[TimeInRole] = "timeIn";
+	roles[SelectedRole] = "selected";
+	roles[TimeOutRole] = "timeOut";
+	return roles;
+}
+
+void PhStripTextModel::clear() {
+	beginRemoveRows(QModelIndex(), 0, rowCount());
+	qDeleteAll(_stripTexts);
+	_stripTexts.clear();
+	endRemoveRows();
+}

--- a/libs/PhGraphicStrip/PhStripTextModel.h
+++ b/libs/PhGraphicStrip/PhStripTextModel.h
@@ -1,0 +1,33 @@
+#ifndef PHSTRIPTEXTMODEL_H
+#define PHSTRIPTEXTMODEL_H
+
+#include <QAbstractListModel>
+#include "PhStrip/PhStripText.h"
+
+class PhStripTextModel : public QAbstractListModel
+{
+	Q_OBJECT
+public:
+	enum NextPeopleRoles {
+		ContentRole = Qt::UserRole + 1,
+		//ColorRole,
+		TimeInRole,
+		SelectedRole,
+		TimeOutRole
+	};
+
+	PhStripTextModel(QObject *parent = 0);
+
+	void addStripText(const PhStripText *stripText);
+	int rowCount(const QModelIndex & parent = QModelIndex()) const;
+	QVariant data(const QModelIndex & index, int role = Qt::DisplayRole) const;
+	void clear();
+
+protected:
+	QHash<int, QByteArray> roleNames() const;
+
+private:
+	QList<const PhStripText*> _stripTexts;
+};
+
+#endif // PHSTRIPTEXTMODEL_H

--- a/libs/PhGraphicStrip/PhTrack.cpp
+++ b/libs/PhGraphicStrip/PhTrack.cpp
@@ -1,0 +1,35 @@
+#include "PhGraphicStrip/PhTrack.h"
+
+PhTrack::PhTrack()
+{
+	_stripTextModel = new PhStripTextModel();
+	_stripPeopleModel = new PhStripTextModel();
+	_offDetectModel = new PhNextPeopleModel();
+	_semiOffDetectModel = new PhNextPeopleModel();
+	_arrowUpDetectModel = new PhNextPeopleModel();
+	_arrowDownDetectModel = new PhNextPeopleModel();
+}
+
+PhStripTextModel * PhTrack::stripTextModel() const {
+	return _stripTextModel;
+}
+
+PhStripTextModel * PhTrack::stripPeopleModel() const {
+	return _stripPeopleModel;
+}
+
+PhNextPeopleModel * PhTrack::offDetectModel() const {
+	return _offDetectModel;
+}
+
+PhNextPeopleModel * PhTrack::semiOffDetectModel() const {
+	return _semiOffDetectModel;
+}
+
+PhNextPeopleModel * PhTrack::arrowUpDetectModel() const {
+	return _arrowUpDetectModel;
+}
+
+PhNextPeopleModel * PhTrack::arrowDownDetectModel() const {
+	return _arrowDownDetectModel;
+}

--- a/libs/PhGraphicStrip/PhTrack.h
+++ b/libs/PhGraphicStrip/PhTrack.h
@@ -1,0 +1,28 @@
+#ifndef PHTRACK_H
+#define PHTRACK_H
+
+#include "PhGraphicStrip/PhNextPeopleModel.h"
+#include "PhGraphicStrip/PhStripTextModel.h"
+
+class PhTrack
+{
+public:
+	PhTrack();
+
+	PhStripTextModel * stripTextModel() const;
+	PhStripTextModel * stripPeopleModel() const;
+	PhNextPeopleModel * offDetectModel() const;
+	PhNextPeopleModel * semiOffDetectModel() const;
+	PhNextPeopleModel * arrowUpDetectModel() const;
+	PhNextPeopleModel * arrowDownDetectModel() const;
+
+private:
+	PhStripTextModel *_stripTextModel;
+	PhStripTextModel *_stripPeopleModel;
+	PhNextPeopleModel *_offDetectModel;
+	PhNextPeopleModel *_semiOffDetectModel;
+	PhNextPeopleModel *_arrowUpDetectModel;
+	PhNextPeopleModel *_arrowDownDetectModel;
+};
+
+#endif // PHTRACK_H

--- a/libs/PhGraphicStrip/PhTrackModel.cpp
+++ b/libs/PhGraphicStrip/PhTrackModel.cpp
@@ -1,0 +1,54 @@
+#include "PhTrackModel.h"
+
+PhTrackModel::PhTrackModel(QObject *parent) :
+	QAbstractListModel(parent)
+{
+}
+
+void PhTrackModel::addTrack(const PhTrack *track)
+{
+	beginInsertRows(QModelIndex(), rowCount(), rowCount());
+	_tracks << track;
+	endInsertRows();
+}
+
+int PhTrackModel::rowCount(const QModelIndex & parent) const {
+	return _tracks.count();
+}
+
+QVariant PhTrackModel::data(const QModelIndex & index, int role) const {
+	if (index.row() < 0 || index.row() >= _tracks.count())
+		return QVariant();
+	const PhTrack *track = _tracks[index.row()];
+	if (role == StripTextRole)
+		return QVariant::fromValue<QObject*>(track->stripTextModel());
+	else if (role == StripPeopleRole)
+		return QVariant::fromValue<QObject*>(track->stripPeopleModel());
+	else if (role == OffDetectRole)
+		return QVariant::fromValue<QObject*>(track->offDetectModel());
+	else if (role == SemiOffDetectRole)
+		return QVariant::fromValue<QObject*>(track->semiOffDetectModel());
+	else if (role == ArrowUpDetectRole)
+		return QVariant::fromValue<QObject*>(track->arrowUpDetectModel());
+	else if (role == ArrowDownDetectRole)
+		return QVariant::fromValue<QObject*>(track->arrowDownDetectModel());
+	return QVariant();
+}
+
+QHash<int, QByteArray> PhTrackModel::roleNames() const {
+	QHash<int, QByteArray> roles;
+	roles[StripTextRole] = "stripText";
+	roles[StripPeopleRole] = "stripPeople";
+	roles[OffDetectRole] = "offDetect";
+	roles[SemiOffDetectRole] = "semiOffDetect";
+	roles[ArrowUpDetectRole] = "arrowUpDetect";
+	roles[ArrowDownDetectRole] = "arrowDownDetect";
+	return roles;
+}
+
+void PhTrackModel::clear() {
+	beginRemoveRows(QModelIndex(), 0, rowCount());
+	qDeleteAll(_tracks);
+	_tracks.clear();
+	endRemoveRows();
+}

--- a/libs/PhGraphicStrip/PhTrackModel.h
+++ b/libs/PhGraphicStrip/PhTrackModel.h
@@ -1,0 +1,34 @@
+#ifndef PHTRACKMODEL_H
+#define PHTRACKMODEL_H
+
+#include <QAbstractListModel>
+#include "PhGraphicStrip/PhTrack.h"
+
+class PhTrackModel : public QAbstractListModel
+{
+	Q_OBJECT
+public:
+	enum TrackRoles {
+		StripTextRole = Qt::UserRole + 1,
+		StripPeopleRole,
+		OffDetectRole,
+		SemiOffDetectRole,
+		ArrowUpDetectRole,
+		ArrowDownDetectRole
+	};
+
+	PhTrackModel(QObject *parent = 0);
+
+	void addTrack(const PhTrack *track);
+	int rowCount(const QModelIndex & parent = QModelIndex()) const;
+	QVariant data(const QModelIndex & index, int role = Qt::DisplayRole) const;
+	void clear();
+
+protected:
+	QHash<int, QByteArray> roleNames() const;
+
+private:
+	QList<const PhTrack*> _tracks;
+};
+
+#endif // PHTRACKMODEL_H

--- a/libs/PhStrip/PhPeople.cpp
+++ b/libs/PhStrip/PhPeople.cpp
@@ -7,6 +7,7 @@
 #include "PhPeople.h"
 
 PhPeople::PhPeople(QString name, QString color)
+	: QObject()
 {
 	_name = name;
 	_color = color;
@@ -17,6 +18,13 @@ QString PhPeople::name()
 	return _name;
 }
 
+void PhPeople::setName(QString name)
+{
+	if(name != _name)
+		emit nameChanged();
+
+	_name = name;
+}
 
 QString PhPeople::color()
 {
@@ -25,5 +33,8 @@ QString PhPeople::color()
 
 void PhPeople::setColor(QString color)
 {
+	if(color != _color)
+		emit colorChanged();
+
 	_color = color;
 }

--- a/libs/PhStrip/PhPeople.cpp
+++ b/libs/PhStrip/PhPeople.cpp
@@ -13,7 +13,7 @@ PhPeople::PhPeople(QString name, QString color)
 	_color = color;
 }
 
-QString PhPeople::name()
+QString PhPeople::name() const
 {
 	return _name;
 }
@@ -26,7 +26,7 @@ void PhPeople::setName(QString name)
 	_name = name;
 }
 
-QString PhPeople::color()
+QString PhPeople::color() const
 {
 	return _color;
 }

--- a/libs/PhStrip/PhPeople.h
+++ b/libs/PhStrip/PhPeople.h
@@ -34,7 +34,7 @@ public:
 	 * @brief Get the name
 	 * @return a string
 	 */
-	QString name();
+	QString name() const;
 	/**
 	 * @brief Set the name
 	 * @param name a string
@@ -44,7 +44,7 @@ public:
 	 * @brief Get the color
 	 * @return a PhColor
 	 */
-	QString color();
+	QString color() const;
 	/**
 	 * @brief Set the color
 	 * @param color a PhColor

--- a/libs/PhStrip/PhPeople.h
+++ b/libs/PhStrip/PhPeople.h
@@ -7,6 +7,7 @@
 #ifndef PHPEOPLE_H
 #define PHPEOPLE_H
 
+#include <QObject>
 #include <QString>
 
 /**
@@ -15,7 +16,12 @@
  * It can also be use to write notes or comments on the strip.
  * For example : NDA (note de l'adaptateur).
  */
-class PhPeople {
+class PhPeople : public QObject {
+
+	Q_OBJECT
+
+	Q_PROPERTY(QString name READ name WRITE setName NOTIFY nameChanged)
+	Q_PROPERTY(QString color READ color WRITE setColor NOTIFY colorChanged)
 
 public:
 	/**
@@ -45,6 +51,9 @@ public:
 	 */
 	void setColor(QString color);
 
+signals:
+	void nameChanged();
+	void colorChanged();
 
 private:
 	/**

--- a/libs/PhStrip/PhStripDoc.cpp
+++ b/libs/PhStrip/PhStripDoc.cpp
@@ -1510,6 +1510,14 @@ QString PhStripDoc::title()
 	return _title;
 }
 
+QString PhStripDoc::fullTitle()
+{
+	QString fullTitle = title();
+	if(episode().length() > 0)
+		fullTitle += " #" + episode();
+	return fullTitle;
+}
+
 QString PhStripDoc::translatedTitle()
 {
 	return _translatedTitle;

--- a/libs/PhStrip/PhStripDoc.h
+++ b/libs/PhStrip/PhStripDoc.h
@@ -31,6 +31,9 @@ class PhStripDoc : public QObject
 {
 	Q_OBJECT
 
+	// make the title available in QML
+	Q_PROPERTY(QString fullTitle READ fullTitle NOTIFY changed)
+
 public:
 	/**
 	 * @brief PhStripDoc constructor
@@ -49,6 +52,12 @@ public:
 	 * @return A string
 	 */
 	QString title();
+
+	/**
+	 * @brief The full title, including episode number if appropriate
+	 * @return A string
+	 */
+	QString fullTitle();
 
 	/**
 	 * @brief The translated title

--- a/libs/PhStrip/PhStripObject.cpp
+++ b/libs/PhStrip/PhStripObject.cpp
@@ -7,12 +7,22 @@
 
 #include "PhStripObject.h"
 
-PhStripObject::PhStripObject(PhTime timeIn) : _timeIn(timeIn)
+PhStripObject::PhStripObject(PhTime timeIn)
+  : QObject(),
+	_timeIn(timeIn)
 {
 }
 
 PhTime PhStripObject::timeIn() {
 	return _timeIn;
+}
+
+void PhStripObject::setTimeIn(PhTime timeIn)
+{
+	if (timeIn != _timeIn) {
+		_timeIn = timeIn;
+		emit timeInChanged();
+	}
 }
 
 bool PhStripObject::dtcomp(PhStripObject *a, PhStripObject *b)

--- a/libs/PhStrip/PhStripObject.cpp
+++ b/libs/PhStrip/PhStripObject.cpp
@@ -13,7 +13,7 @@ PhStripObject::PhStripObject(PhTime timeIn)
 {
 }
 
-PhTime PhStripObject::timeIn() {
+PhTime PhStripObject::timeIn() const {
 	return _timeIn;
 }
 

--- a/libs/PhStrip/PhStripObject.h
+++ b/libs/PhStrip/PhStripObject.h
@@ -40,7 +40,7 @@ public:
 	 * @brief The time in
 	 * @return A PhTime
 	 */
-	PhTime timeIn();
+	PhTime timeIn() const;
 
 	/**
 	 * @brief Set the time in

--- a/libs/PhStrip/PhStripObject.h
+++ b/libs/PhStrip/PhStripObject.h
@@ -14,7 +14,11 @@
  *
  * Its only property is timeIn.
  */
-class PhStripObject {
+class PhStripObject : public QObject {
+
+	Q_OBJECT
+
+	Q_PROPERTY(PhTime timeIn READ timeIn WRITE setTimeIn NOTIFY timeInChanged)
 
 private:
 	/**
@@ -39,6 +43,12 @@ public:
 	PhTime timeIn();
 
 	/**
+	 * @brief Set the time in
+	 * @param timeIn a PhTime
+	 */
+	void setTimeIn(PhTime timeIn);
+
+	/**
 	 * @brief Compare two strip object based on the time in
 	 *
 	 * @param a A strip object
@@ -46,6 +56,9 @@ public:
 	 * @return True if "a" has a stricly lower time in than "b", false otherwise.
 	 */
 	static bool dtcomp(PhStripObject *a, PhStripObject *b);
+
+signals:
+	void timeInChanged();
 };
 
 #endif // PHSTRIPOBJECT_H

--- a/libs/PhStrip/PhStripPeopleObject.cpp
+++ b/libs/PhStrip/PhStripPeopleObject.cpp
@@ -19,7 +19,10 @@ float PhStripPeopleObject::height() const
 
 void PhStripPeopleObject::setHeight(float height)
 {
-	_height = height;
+	if (height != _height) {
+		_height = height;
+		emit heightChanged();
+	}
 }
 
 

--- a/libs/PhStrip/PhStripPeopleObject.h
+++ b/libs/PhStrip/PhStripPeopleObject.h
@@ -38,7 +38,7 @@ public:
 	 * @brief Get the PhPeople
 	 * @return _people the corresponding PhPeople
 	 */
-	PhPeople * people() {
+	PhPeople * people() const {
 		return _people;
 	}
 	/**
@@ -52,7 +52,7 @@ public:
 	 * @brief The time out
 	 * @return A time value
 	 */
-	PhTime timeOut() {
+	PhTime timeOut() const {
 		return _timeOut;
 	}
 	/**

--- a/libs/PhStrip/PhStripPeopleObject.h
+++ b/libs/PhStrip/PhStripPeopleObject.h
@@ -17,6 +17,12 @@
  */
 class PhStripPeopleObject : public PhStripObject {
 
+	Q_OBJECT
+
+	Q_PROPERTY(float y READ y WRITE setY NOTIFY yChanged)
+	Q_PROPERTY(float height READ height WRITE setHeight NOTIFY heightChanged)
+	Q_PROPERTY(PhTime timeOut READ timeOut WRITE setTimeOut NOTIFY timeOutChanged)
+
 public:
 
 	/**
@@ -61,14 +67,20 @@ public:
 	 * @param y An float between 0 and 1
 	 */
 	void setY(float y) {
-		_y = y;
+		if (y != _y) {
+			_y = y;
+			emit yChanged();
+		}
 	}
 	/**
 	 * @brief Set the time out
 	 * @param timeOut A time
 	 */
 	void setTimeOut(PhTime timeOut) {
-		_timeOut = timeOut;
+		if (timeOut != _timeOut) {
+			_timeOut = timeOut;
+			emit timeOutChanged();
+		}
 	}
 	/**
 	 * @brief Height of the text
@@ -80,6 +92,11 @@ public:
 	 * @param height the fraction desired of the track height
 	 */
 	void setHeight(float height);
+
+signals:
+	void heightChanged();
+	void yChanged();
+	void timeOutChanged();
 
 private:
 	/**

--- a/libs/PhStrip/PhStripText.cpp
+++ b/libs/PhStrip/PhStripText.cpp
@@ -8,13 +8,27 @@
 
 
 
-PhStripText::PhStripText(PhTime timeIn, PhPeople *people, PhTime timeOut, float track, QString content, float height) :
-	PhStripPeopleObject(timeIn, people, timeOut, track, height), _content(content)
+PhStripText::PhStripText(PhTime timeIn, PhPeople *people, PhTime timeOut, float track, QString content, float height, bool selected) :
+	PhStripPeopleObject(timeIn, people, timeOut, track, height),
+	_content(content),
+	_selected(selected)
 {
 }
 
-QString PhStripText::content()
+QString PhStripText::content() const
 {
 	return _content;
 }
 
+bool PhStripText::selected() const
+{
+	return _selected;
+}
+
+void PhStripText::setSelected(bool selected)
+{
+	if (selected != _selected) {
+		_selected = selected;
+		emit selectedChanged();
+	}
+}

--- a/libs/PhStrip/PhStripText.cpp
+++ b/libs/PhStrip/PhStripText.cpp
@@ -20,6 +20,14 @@ QString PhStripText::content() const
 	return _content;
 }
 
+void PhStripText::setContent(QString content)
+{
+	if (content != _content) {
+		_content = content;
+		emit contentChanged();
+	}
+}
+
 bool PhStripText::selected() const
 {
 	return _selected;

--- a/libs/PhStrip/PhStripText.h
+++ b/libs/PhStrip/PhStripText.h
@@ -38,6 +38,11 @@ public:
 	 * @return _content
 	 */
 	QString content() const;
+	/**
+	 * @brief Set the text content
+	 * @param content a string
+	 */
+	void setContent(QString content);
 
 	/**
 	 * @brief Get whether this person is selected

--- a/libs/PhStrip/PhStripText.h
+++ b/libs/PhStrip/PhStripText.h
@@ -32,15 +32,27 @@ public:
 	 * @param content the content of the text
 	 * @param height the track height
 	 */
-	PhStripText( PhTime timeIn, PhPeople * people, PhTime timeOut, float track,  QString content, float height);
+	PhStripText( PhTime timeIn, PhPeople * people, PhTime timeOut, float track,  QString content, float height, bool selected = true);
 	/**
 	 * @brief Get the text content
 	 * @return _content
 	 */
-	QString content();
+	QString content() const;
+
+	/**
+	 * @brief Get whether this person is selected
+	 * @return a bool
+	 */
+	bool selected() const;
+	/**
+	 * @brief Set whether this person is selected
+	 * @param selected a bool
+	 */
+	void setSelected(bool selected);
 
 signals:
 	void contentChanged();
+	void selectedChanged();
 
 private:
 
@@ -48,6 +60,7 @@ private:
  * Text string of Sentence or part of a sentence.
  */
 	QString _content;
+	bool _selected;
 };
 
 #endif // PHSTRIPTEXT_H

--- a/libs/PhStrip/PhStripText.h
+++ b/libs/PhStrip/PhStripText.h
@@ -17,6 +17,10 @@
  */
 class PhStripText : public PhStripPeopleObject {
 
+	Q_OBJECT
+
+	Q_PROPERTY(QString content READ content NOTIFY contentChanged)
+
 public:
 
 	/**
@@ -34,6 +38,9 @@ public:
 	 * @return _content
 	 */
 	QString content();
+
+signals:
+	void contentChanged();
 
 private:
 

--- a/libs/PhVideo/PhVideo.pri
+++ b/libs/PhVideo/PhVideo.pri
@@ -25,14 +25,14 @@ win32{
 	LIBS += -L$$(FFMPEG_DEV_PATH)\lib -lavformat -lavcodec -lavutil -lswscale -liconv -lz
 
 
-	QMAKE_POST_LINK += $${QMAKE_COPY} $$shell_path($$(FFMPEG_SHARED_PATH)/bin/swscale-2.dll) $${RESOURCES_PATH} $${CS}
-	QMAKE_POST_LINK += $${QMAKE_COPY} $$shell_path($$(FFMPEG_SHARED_PATH)/bin/avcodec-55.dll) $${RESOURCES_PATH} $${CS}
+	QMAKE_POST_LINK += $${QMAKE_COPY} $$shell_path($$(FFMPEG_SHARED_PATH)/bin/swscale-3.dll) $${RESOURCES_PATH} $${CS}
+	QMAKE_POST_LINK += $${QMAKE_COPY} $$shell_path($$(FFMPEG_SHARED_PATH)/bin/avcodec-56.dll) $${RESOURCES_PATH} $${CS}
 	QMAKE_POST_LINK += $${QMAKE_COPY} $$shell_path($$(FFMPEG_SHARED_PATH)/bin/avdevice-55.dll) $${RESOURCES_PATH} $${CS}
 	QMAKE_POST_LINK += $${QMAKE_COPY} $$shell_path($$(FFMPEG_SHARED_PATH)/bin/avfilter-4.dll) $${RESOURCES_PATH} $${CS}
-	QMAKE_POST_LINK += $${QMAKE_COPY} $$shell_path($$(FFMPEG_SHARED_PATH)/bin/avformat-55.dll) $${RESOURCES_PATH} $${CS}
-	QMAKE_POST_LINK += $${QMAKE_COPY} $$shell_path($$(FFMPEG_SHARED_PATH)/bin/avutil-52.dll) $${RESOURCES_PATH} $${CS}
+	QMAKE_POST_LINK += $${QMAKE_COPY} $$shell_path($$(FFMPEG_SHARED_PATH)/bin/avformat-56.dll) $${RESOURCES_PATH} $${CS}
+	QMAKE_POST_LINK += $${QMAKE_COPY} $$shell_path($$(FFMPEG_SHARED_PATH)/bin/avutil-54.dll) $${RESOURCES_PATH} $${CS}
 	QMAKE_POST_LINK += $${QMAKE_COPY} $$shell_path($$(FFMPEG_SHARED_PATH)/bin/postproc-52.dll) $${RESOURCES_PATH} $${CS}
-	QMAKE_POST_LINK += $${QMAKE_COPY} $$shell_path($$(FFMPEG_SHARED_PATH)/bin/swresample-0.dll) $${RESOURCES_PATH} $${CS}
+	QMAKE_POST_LINK += $${QMAKE_COPY} $$shell_path($$(FFMPEG_SHARED_PATH)/bin/swresample-1.dll) $${RESOURCES_PATH} $${CS}
 
 }
 

--- a/libs/PhVideo/PhVideo.pri
+++ b/libs/PhVideo/PhVideo.pri
@@ -24,16 +24,14 @@ win32{
 	INCLUDEPATH += $$(FFMPEG_DEV_PATH)\include
 	LIBS += -L$$(FFMPEG_DEV_PATH)\lib -lavformat -lavcodec -lavutil -lswscale -liconv -lz
 
-
-	QMAKE_POST_LINK += $${QMAKE_COPY} $$shell_path($$(FFMPEG_SHARED_PATH)/bin/swscale-3.dll) $${RESOURCES_PATH} $${CS}
 	QMAKE_POST_LINK += $${QMAKE_COPY} $$shell_path($$(FFMPEG_SHARED_PATH)/bin/avcodec-56.dll) $${RESOURCES_PATH} $${CS}
-	QMAKE_POST_LINK += $${QMAKE_COPY} $$shell_path($$(FFMPEG_SHARED_PATH)/bin/avdevice-55.dll) $${RESOURCES_PATH} $${CS}
-	QMAKE_POST_LINK += $${QMAKE_COPY} $$shell_path($$(FFMPEG_SHARED_PATH)/bin/avfilter-4.dll) $${RESOURCES_PATH} $${CS}
+	QMAKE_POST_LINK += $${QMAKE_COPY} $$shell_path($$(FFMPEG_SHARED_PATH)/bin/avdevice-56.dll) $${RESOURCES_PATH} $${CS}
+	QMAKE_POST_LINK += $${QMAKE_COPY} $$shell_path($$(FFMPEG_SHARED_PATH)/bin/avfilter-5.dll) $${RESOURCES_PATH} $${CS}
 	QMAKE_POST_LINK += $${QMAKE_COPY} $$shell_path($$(FFMPEG_SHARED_PATH)/bin/avformat-56.dll) $${RESOURCES_PATH} $${CS}
 	QMAKE_POST_LINK += $${QMAKE_COPY} $$shell_path($$(FFMPEG_SHARED_PATH)/bin/avutil-54.dll) $${RESOURCES_PATH} $${CS}
-	QMAKE_POST_LINK += $${QMAKE_COPY} $$shell_path($$(FFMPEG_SHARED_PATH)/bin/postproc-52.dll) $${RESOURCES_PATH} $${CS}
+	QMAKE_POST_LINK += $${QMAKE_COPY} $$shell_path($$(FFMPEG_SHARED_PATH)/bin/postproc-53.dll) $${RESOURCES_PATH} $${CS}
 	QMAKE_POST_LINK += $${QMAKE_COPY} $$shell_path($$(FFMPEG_SHARED_PATH)/bin/swresample-1.dll) $${RESOURCES_PATH} $${CS}
-
+	QMAKE_POST_LINK += $${QMAKE_COPY} $$shell_path($$(FFMPEG_SHARED_PATH)/bin/swscale-3.dll) $${RESOURCES_PATH} $${CS}
 }
 
 # Unix specific

--- a/libs/PhVideo/PhVideo.pri
+++ b/libs/PhVideo/PhVideo.pri
@@ -5,9 +5,11 @@
 
 HEADERS += \
     ../../libs/PhVideo/PhVideoEngine.h \
-    ../../libs/PhVideo/PhVideoSettings.h
+    ../../libs/PhVideo/PhVideoSettings.h \
+    $$PWD/PhVideoSurface.h
 SOURCES += \
-    ../../libs/PhVideo/PhVideoEngine.cpp
+    ../../libs/PhVideo/PhVideoEngine.cpp \
+    $$PWD/PhVideoSurface.cpp
 
 # Windows specific
 win32{

--- a/libs/PhVideo/PhVideoEngine.h
+++ b/libs/PhVideo/PhVideoEngine.h
@@ -23,6 +23,7 @@ extern "C" {
 
 #include <QObject>
 #include <QElapsedTimer>
+#include <QVideoFrame>
 
 #include "PhSync/PhClock.h"
 #include "PhTools/PhTickCounter.h"
@@ -213,12 +214,19 @@ public:
 	 */
 	void drawVideo(int x, int y, int w, int h);
 
+	/**
+	 * @brief decode the video for the current time (may not do anything if not needed)
+	 */
+	void decodeVideo();
+
 signals:
 	/**
 	 * @brief Signal sent upon a different timecode type message
 	 * @param tcType A timecode type value.
 	 */
 	void timeCodeTypeChanged(PhTimeCodeType tcType);
+
+	void newVideoContentProduced(const QVideoFrame &frame);
 
 private:
 	bool goToFrame(PhFrame frame);

--- a/libs/PhVideo/PhVideoSurface.cpp
+++ b/libs/PhVideo/PhVideoSurface.cpp
@@ -1,0 +1,40 @@
+#include "PhVideoSurface.h"
+
+PhVideoSurface::PhVideoSurface()
+	: m_surface(NULL)
+{
+	m_format = QVideoSurfaceFormat();
+}
+
+QAbstractVideoSurface* PhVideoSurface::videoSurface() const
+{
+	return m_surface;
+}
+
+void PhVideoSurface::setVideoSurface(QAbstractVideoSurface *surface)
+{
+	if (m_surface != surface && m_surface && m_surface->isActive()) {
+		m_surface->stop();
+	}
+
+	m_surface = surface;
+
+	if (m_surface && m_format.isValid())
+		m_surface->start(m_format);
+}
+
+void PhVideoSurface::onNewVideoContentReceived(const QVideoFrame &frame)
+{
+	// should set the format
+	if ((m_format.frameSize() != frame.size())
+			|| (m_format.pixelFormat() != frame.pixelFormat()))
+	{
+		m_format = QVideoSurfaceFormat(frame.size(), frame.pixelFormat());
+
+		if (m_surface && m_format.isValid())
+			m_surface->start(m_format);
+	}
+
+	if (m_surface)
+		m_surface->present(frame);
+}

--- a/libs/PhVideo/PhVideoSurface.h
+++ b/libs/PhVideo/PhVideoSurface.h
@@ -1,0 +1,27 @@
+#ifndef PHVIDEOSURFACE_H
+#define PHVIDEOSURFACE_H
+
+#include <QAbstractVideoSurface>
+#include <QVideoSurfaceFormat>
+
+class PhVideoSurface : public QObject
+{
+	Q_OBJECT
+	Q_PROPERTY(QAbstractVideoSurface *videoSurface READ videoSurface WRITE setVideoSurface)
+
+public:
+	PhVideoSurface();
+
+	QAbstractVideoSurface* videoSurface() const;
+
+	void setVideoSurface(QAbstractVideoSurface *surface);
+
+public slots:
+	void onNewVideoContentReceived(const QVideoFrame &frame);
+
+private:
+	QAbstractVideoSurface *m_surface;
+	QVideoSurfaceFormat m_format;
+};
+
+#endif // PHVIDEOSURFACE_H


### PR DESCRIPTION
Dear Martin,

Here is a pull request about moving away from OpenGL and using QML instead. OpenGL can be fast, but it is hard to keep it fast when drawing complex scenes without a little help from a higher level library. QML fits nicely there. It manages a scene graph of what is to be displayed, so that fewer calls to OpenGL are made. Moreover, it allows to obtain nice graphical effects with less effort than raw OpenGL drawing functions.

The branch where I worked was created a while ago, so I am sure that there will be tons of merge conflicts. And some tests are surely failing...

Anyway the basic structure is there. It involved splitting the logic to follow the model/view/controller pattern. The boilerplate code to make it compile and run successfully (even outside Qt Creator) is there too.

Feel free to comment!

Thanks,

Timothée