### PR TITLE
Decode the video frame asynchronously in a separate thread

### DIFF
--- a/libs/PhVideo/PhVideo.pri
+++ b/libs/PhVideo/PhVideo.pri
@@ -5,9 +5,11 @@
 
 HEADERS += \
     $$PWD/PhVideoEngine.h \
-    $$PWD/PhVideoSettings.h
+	$$PWD/PhVideoSettings.h \
+	$$PWD/PhVideoDecoder.h
 SOURCES += \
-    $$PWD/PhVideoEngine.cpp
+	$$PWD/PhVideoEngine.cpp \
+	$$PWD/PhVideoDecoder.cpp
 
 # Windows specific
 win32{

--- a/libs/PhVideo/PhVideoDecoder.cpp
+++ b/libs/PhVideo/PhVideoDecoder.cpp
@@ -45,7 +45,8 @@ void PhVideoDecoder::open(QString fileName)
 	if (avformat_find_stream_info(_formatContext, NULL) < 0)
 		return; // Couldn't find stream information
 
-	av_dump_format(_formatContext, 0, fileName.toStdString().c_str(), 0);
+	// PhVideoEngine already dumps the stream info, do not do it again here.
+	//av_dump_format(_formatContext, 0, fileName.toStdString().c_str(), 0);
 
 	// Find video stream :
 	for(int i = 0; i < (int)_formatContext->nb_streams; i++) {

--- a/libs/PhVideo/PhVideoDecoder.cpp
+++ b/libs/PhVideo/PhVideoDecoder.cpp
@@ -1,0 +1,305 @@
+/**
+ * @file
+ * @copyright (C) 2012-2014 Phonations
+ * @license http://www.gnu.org/licenses/gpl.html GPL version 2 or higher
+ */
+
+#include "PhTools/PhGeneric.h"
+#include "PhTools/PhDebug.h"
+
+#include "PhVideoDecoder.h"
+
+PhVideoDecoder::PhVideoDecoder() :
+	_fileName(""),
+	_tcType(PhTimeCodeType25),
+	_formatContext(NULL),
+	_videoStream(NULL),
+	_videoFrame(NULL),
+	_swsContext(NULL),
+	_currentTime(PHTIMEMIN),
+	_useAudio(false),
+	_audioStream(NULL),
+	_audioFrame(NULL)
+{
+	PHDEBUG << "Using FFMpeg widget for video playback.";
+	av_register_all();
+	avcodec_register_all();
+}
+
+bool PhVideoDecoder::ready()
+{
+	return (_formatContext && _videoStream && _videoFrame);
+}
+
+void PhVideoDecoder::open(QString fileName)
+{
+	close();
+	PHDEBUG << fileName;
+
+	_currentTime = PHTIMEMIN;
+
+	if(avformat_open_input(&_formatContext, fileName.toStdString().c_str(), NULL, NULL) < 0)
+		return;
+
+	PHDEBUG << "Retrieve stream information";
+	if (avformat_find_stream_info(_formatContext, NULL) < 0)
+		return; // Couldn't find stream information
+
+	av_dump_format(_formatContext, 0, fileName.toStdString().c_str(), 0);
+
+	// Find video stream :
+	for(int i = 0; i < (int)_formatContext->nb_streams; i++) {
+		AVMediaType streamType = _formatContext->streams[i]->codec->codec_type;
+		PHDEBUG << i << ":" << streamType;
+		switch(streamType) {
+		case AVMEDIA_TYPE_VIDEO:
+			_videoStream = _formatContext->streams[i];
+			PHDEBUG << "\t=> video";
+			break;
+		case AVMEDIA_TYPE_AUDIO:
+			if(_useAudio && (_audioStream == NULL))
+				_audioStream = _formatContext->streams[i];
+			PHDEBUG << "\t=> audio";
+			break;
+		default:
+			PHDEBUG << "\t=> unknown";
+			break;
+		}
+	}
+
+	if(_videoStream == NULL)
+		return;
+
+	// Looking for timecode type
+	_tcType = PhTimeCode::computeTimeCodeType(this->framePerSecond());
+
+	PHDEBUG << "size : " << _videoStream->codec->width << "x" << _videoStream->codec->height;
+	AVCodec * videoCodec = avcodec_find_decoder(_videoStream->codec->codec_id);
+	if(videoCodec == NULL) {
+		PHDEBUG << "Unable to find the codec:" << _videoStream->codec->codec_id;
+		return;
+	}
+
+	if (avcodec_open2(_videoStream->codec, videoCodec, NULL) < 0) {
+		PHDEBUG << "Unable to open the codec:" << _videoStream->codec;
+		return;
+	}
+
+	_videoFrame = av_frame_alloc();
+
+	if(_audioStream) {
+		AVCodec* audioCodec = avcodec_find_decoder(_audioStream->codec->codec_id);
+		if(audioCodec) {
+			if(avcodec_open2(_audioStream->codec, audioCodec, NULL) < 0) {
+				PHDEBUG << "Unable to open audio codec.";
+				_audioStream = NULL;
+			}
+			else {
+				_audioFrame = av_frame_alloc();
+				PHDEBUG << "Audio OK.";
+			}
+		}
+		else {
+			PHDEBUG << "Unable to find codec for audio.";
+			_audioStream = NULL;
+		}
+	}
+
+	_fileName = fileName;
+}
+
+void PhVideoDecoder::close()
+{
+	PHDEBUG << _fileName;
+
+	if (_swsContext) {
+		sws_freeContext(_swsContext);
+		_swsContext = NULL;
+	}
+
+	if(_formatContext) {
+		PHDEBUG << "Close the media context.";
+		if(_videoStream)
+			avcodec_close(_videoStream->codec);
+		if(_audioStream)
+			avcodec_close(_audioStream->codec);
+		avformat_close_input(&_formatContext);
+	}
+
+	if (_videoFrame) {
+		av_frame_free(&_videoFrame);
+		_videoFrame = NULL;
+	}
+
+	_formatContext = NULL;
+	_videoStream = NULL;
+	_audioStream = NULL;
+	PHDEBUG << _fileName << "closed";
+
+	_fileName = "";
+}
+
+PhVideoDecoder::~PhVideoDecoder()
+{
+	close();
+}
+
+PhTime PhVideoDecoder::length()
+{
+	if(_videoStream)
+		return AVTimestamp_to_PhTime(_videoStream->duration);
+	return 0;
+}
+
+double PhVideoDecoder::framePerSecond()
+{
+	// default is 25 fps.
+	// It will be used when loading a collection of image files (as it is done in the tests and specs),
+	// where ffmpeg framerate is undefined (avg_frame_rate.den is 0).
+	double result = 25.00f;
+
+	if(_videoStream && (_videoStream->avg_frame_rate.den != 0)) {
+		result =  av_q2d(_videoStream->avg_frame_rate);
+	}
+
+	return result;
+}
+
+void PhVideoDecoder::decodeFrame(PhTime time, uint8_t *rgb, bool deinterlace)
+{
+	if(!ready()) {
+		PHDEBUG << "not ready";
+		return;
+	}
+
+	// clip to stream boundaries
+	if(time < 0)
+		time = 0;
+	if (time >= this->length())
+		time = this->length();
+
+	// Stay with the same frame if the time has changed less than the time between two frames
+	// Note that av_seek_frame will seek to the _closest_ frame, sometimes a little bit in the "future",
+	// so it is necessary to use a little margin for the second comparison, otherwise a seek may
+	// be performed on each call to decodeFrame
+	if ((time < _currentTime + PhTimeCode::timePerFrame(_tcType))
+		&& (time > _currentTime - PhTimeCode::timePerFrame(_tcType)/2)) {
+		return;
+	}
+
+	// we need to perform a frame seek if the requested frame is not the next frame in the stream
+	if((time >= _currentTime + 2*PhTimeCode::timePerFrame(_tcType))
+	   || (time < _currentTime)) {
+		int flags = AVSEEK_FLAG_ANY;
+		int64_t timestamp = PhTime_to_AVTimestamp(time);
+		PHDEBUG << "seek:" << time << " " << _currentTime << " " << " " << timestamp;
+		av_seek_frame(_formatContext, _videoStream->index, timestamp, flags);
+	}
+
+	AVPacket packet;
+
+	bool lookingForVideoFrame = true;
+	while(lookingForVideoFrame) {
+		int error = av_read_frame(_formatContext, &packet);
+		switch(error) {
+		case 0:
+			if(packet.stream_index == _videoStream->index) {
+				int frameFinished = 0;
+				avcodec_decode_video2(_videoStream->codec, _videoFrame, &frameFinished, &packet);
+				if(frameFinished) {
+
+					int frameHeight = _videoFrame->height;
+					if(deinterlace)
+						frameHeight = _videoFrame->height / 2;
+
+					// As the following formats are deprecated (see https://libav.org/doxygen/master/pixfmt_8h.html#a9a8e335cf3be472042bc9f0cf80cd4c5)
+					// we replace its with the new ones recommended by LibAv
+					// in order to get ride of the warnings
+					AVPixelFormat pixFormat;
+					switch (_videoStream->codec->pix_fmt) {
+					case AV_PIX_FMT_YUVJ420P:
+						pixFormat = AV_PIX_FMT_YUV420P;
+						break;
+					case AV_PIX_FMT_YUVJ422P:
+						pixFormat = AV_PIX_FMT_YUV422P;
+						break;
+					case AV_PIX_FMT_YUVJ444P:
+						pixFormat = AV_PIX_FMT_YUV444P;
+						break;
+					case AV_PIX_FMT_YUVJ440P:
+						pixFormat = AV_PIX_FMT_YUV440P;
+					default:
+						pixFormat = _videoStream->codec->pix_fmt;
+						break;
+					}
+					/* Note: we output the frames in AV_PIX_FMT_BGRA rather than AV_PIX_FMT_RGB24,
+					 * because this format is native to most video cards and will avoid a conversion
+					 * in the video driver */
+					/* sws_getCachedContext will check if the context is valid for the given parameters. It the context is not valid,
+					 * it will be freed and a new one will be allocated. */
+					_swsContext = sws_getCachedContext(_swsContext, _videoFrame->width, _videoStream->codec->height, pixFormat,
+													   _videoStream->codec->width, frameHeight, AV_PIX_FMT_BGRA,
+													   SWS_POINT, NULL, NULL, NULL);
+
+
+					int linesize = _videoFrame->width * 4;
+					if (0 <= sws_scale(_swsContext, (const uint8_t * const *) _videoFrame->data,
+									   _videoFrame->linesize, 0, _videoStream->codec->height, &rgb,
+									   &linesize)) {
+
+						PhTime time = AVTimestamp_to_PhTime(av_frame_get_best_effort_timestamp(_videoFrame));
+
+						// tell the video engine that we have finished decoding!
+						emit frameAvailable(time, rgb, _videoFrame->width, frameHeight);
+					}
+					lookingForVideoFrame = false;
+				} // if frame decode is not finished, let's read another packet.
+			}
+			else if(_audioStream && (packet.stream_index == _audioStream->index)) {
+				int ok = 0;
+				avcodec_decode_audio4(_audioStream->codec, _audioFrame, &ok, &packet);
+				if(ok) {
+					PHDEBUG << "audio:" << _audioFrame->nb_samples;
+				}
+			}
+			break;
+		case AVERROR_INVALIDDATA:
+		case AVERROR_EOF:
+		default:
+			{
+				char errorStr[256];
+				av_strerror(error, errorStr, 256);
+				PHDEBUG << time << "error:" << errorStr;
+				lookingForVideoFrame = false;
+				break;
+			}
+		}
+
+		// update the current position of the engine
+		// (Note that it is best not to do use '_currentTime = time' here, because the seeking operation may
+		// not be 100% accurate: the actual time may be different from the requested time. So a time drift
+		// could appear.)
+		_currentTime = AVTimestamp_to_PhTime(av_frame_get_best_effort_timestamp(_videoFrame));
+
+		//Avoid memory leak
+		av_free_packet(&packet);
+	}
+}
+
+int64_t PhVideoDecoder::PhTime_to_AVTimestamp(PhTime time)
+{
+	int64_t timestamp = 0;
+	if(_videoStream) {
+		timestamp = static_cast<int64_t>(std::round(static_cast<double>(time) / 24000. / av_q2d(_videoStream->time_base)));
+	}
+	return timestamp;
+}
+
+PhTime PhVideoDecoder::AVTimestamp_to_PhTime(int64_t timestamp)
+{
+	PhTime time = 0;
+	if(_videoStream) {
+		time = static_cast<PhTime>(std::round(static_cast<double>(timestamp) * av_q2d(_videoStream->time_base) * 24000.));
+	}
+	return time;
+}

--- a/libs/PhVideo/PhVideoDecoder.cpp
+++ b/libs/PhVideo/PhVideoDecoder.cpp
@@ -183,7 +183,7 @@ void PhVideoDecoder::decodeFrame(PhTime time, uint8_t *rgb, bool deinterlace)
 	// so it is necessary to use a little margin for the second comparison, otherwise a seek may
 	// be performed on each call to decodeFrame
 	if ((time < _currentTime + PhTimeCode::timePerFrame(_tcType))
-		&& (time > _currentTime - PhTimeCode::timePerFrame(_tcType)/2)) {
+	    && (time > _currentTime - PhTimeCode::timePerFrame(_tcType)/2)) {
 		return;
 	}
 
@@ -238,14 +238,14 @@ void PhVideoDecoder::decodeFrame(PhTime time, uint8_t *rgb, bool deinterlace)
 					/* sws_getCachedContext will check if the context is valid for the given parameters. It the context is not valid,
 					 * it will be freed and a new one will be allocated. */
 					_swsContext = sws_getCachedContext(_swsContext, _videoFrame->width, _videoStream->codec->height, pixFormat,
-													   _videoStream->codec->width, frameHeight, AV_PIX_FMT_BGRA,
-													   SWS_POINT, NULL, NULL, NULL);
+					                                   _videoStream->codec->width, frameHeight, AV_PIX_FMT_BGRA,
+					                                   SWS_POINT, NULL, NULL, NULL);
 
 
 					int linesize = _videoFrame->width * 4;
 					if (0 <= sws_scale(_swsContext, (const uint8_t * const *) _videoFrame->data,
-									   _videoFrame->linesize, 0, _videoStream->codec->height, &rgb,
-									   &linesize)) {
+					                   _videoFrame->linesize, 0, _videoStream->codec->height, &rgb,
+					                   &linesize)) {
 
 						PhTime time = AVTimestamp_to_PhTime(av_frame_get_best_effort_timestamp(_videoFrame));
 

--- a/libs/PhVideo/PhVideoDecoder.h
+++ b/libs/PhVideo/PhVideoDecoder.h
@@ -77,6 +77,7 @@ private:
 	bool ready();
 	double framePerSecond();
 	PhTime length();
+	void frameToRgb(uint8_t *rgb, bool deinterlace);
 
 	int64_t PhTime_to_AVTimestamp(PhTime time);
 	PhTime AVTimestamp_to_PhTime(int64_t timestamp);

--- a/libs/PhVideo/PhVideoDecoder.h
+++ b/libs/PhVideo/PhVideoDecoder.h
@@ -1,0 +1,98 @@
+/**
+ * @file
+ * @copyright (C) 2012-2015 Phonations
+ * @license http://www.gnu.org/licenses/gpl.html GPL version 2 or higher
+ */
+
+#ifndef PHVIDEODECODER_H
+#define PHVIDEODECODER_H
+
+extern "C" {
+#ifndef INT64_C
+/** see http://code.google.com/p/ffmpegsource/issues/detail?id=11#c13 */
+#define INT64_C(c) (c ## LL)
+/** and http://code.google.com/p/ffmpegsource/issues/detail?id=11#c23 */
+#define UINT64_C(c) (c ## ULL)
+#endif
+
+#include <libavformat/avformat.h>
+#include <libavutil/avutil.h>
+#include <libavcodec/avcodec.h>
+#include <libswscale/swscale.h>
+}
+
+#include "PhSync/PhClock.h"
+
+/**
+ * @brief The video decoder
+ *
+ * It decodes frames from a video file.
+ * The frames are requested by the engine and provided to the engine asynchronously,
+ * using signal and slots. This allows the decoder to work in a separate thread without blocking the GUI.
+ */
+class PhVideoDecoder : public QObject
+{
+	Q_OBJECT
+public:
+	/**
+	 * @brief PhVideoEngine constructor
+	 */
+	explicit PhVideoDecoder();
+
+	~PhVideoDecoder();
+
+public slots:
+	/**
+	 * @brief Open a video file
+	 * @param fileName A video file path
+	 */
+	void open(QString fileName);
+
+	/**
+	 * @brief Close
+	 *
+	 * Close the PhVideoDecoder, freeing all objects
+	 */
+	void close();
+
+	/**
+	 * @brief decode a video frame
+	 * @param time the time of the requested frame (with origin at the start of video file)
+	 * @param rgbBuffer the buffer where to output the decoded frame
+	 * @param deinterlace whether the frame is to be deinterlaced
+	 */
+	void decodeFrame(PhTime time, uint8_t *rgbBuffer, bool deinterlace);
+
+signals:
+	/**
+	 * @brief Signal sent when a frame has been decoded
+	 * @param time the time of the decoded frame (with origin at the start of video file)
+	 * @param rgbBuffer the buffer where the decoded frame is
+	 * @param width the width of the frame
+	 * @param height the height of the frame
+	 */
+	void frameAvailable(PhTime, uint8_t *rgb, int width, int height);
+
+private:
+	bool ready();
+	double framePerSecond();
+	PhTime length();
+
+	int64_t PhTime_to_AVTimestamp(PhTime time);
+	PhTime AVTimestamp_to_PhTime(int64_t timestamp);
+
+	QString _fileName;
+	PhTimeCodeType _tcType;
+
+	AVFormatContext * _formatContext;
+	AVStream *_videoStream;
+	AVFrame * _videoFrame;
+	struct SwsContext * _swsContext;
+	PhTime _currentTime;
+
+	bool _useAudio;
+	AVStream *_audioStream;
+	AVFrame * _audioFrame;
+};
+
+#endif // PHVIDEODECODER_H

--- a/libs/PhVideo/PhVideoDecoder.h
+++ b/libs/PhVideo/PhVideoDecoder.h
@@ -58,20 +58,20 @@ public slots:
 	/**
 	 * @brief decode a video frame
 	 * @param time the time of the requested frame (with origin at the start of video file)
-	 * @param rgbBuffer the buffer where to output the decoded frame
+	 * @param rgb the buffer where to output the decoded frame
 	 * @param deinterlace whether the frame is to be deinterlaced
 	 */
-	void decodeFrame(PhTime time, uint8_t *rgbBuffer, bool deinterlace);
+	void decodeFrame(PhTime time, uint8_t *rgb, bool deinterlace);
 
 signals:
 	/**
 	 * @brief Signal sent when a frame has been decoded
 	 * @param time the time of the decoded frame (with origin at the start of video file)
-	 * @param rgbBuffer the buffer where the decoded frame is
+	 * @param rgb the buffer where the decoded frame is
 	 * @param width the width of the frame
 	 * @param height the height of the frame
 	 */
-	void frameAvailable(PhTime, uint8_t *rgb, int width, int height);
+	void frameAvailable(PhTime time, uint8_t *rgb, int width, int height);
 
 private:
 	bool ready();

--- a/libs/PhVideo/PhVideoEngine.cpp
+++ b/libs/PhVideo/PhVideoEngine.cpp
@@ -29,13 +29,13 @@ PhVideoEngine::PhVideoEngine(PhVideoSettings *settings) :
 
 	// initialize the decoder that operates in a separate thread
 	PhVideoDecoder *decoder = new PhVideoDecoder();
-	decoder->moveToThread(&decoderThread);
-	connect(&decoderThread, &QThread::finished, decoder, &QObject::deleteLater);
+	decoder->moveToThread(&_decoderThread);
+	connect(&_decoderThread, &QThread::finished, decoder, &QObject::deleteLater);
 	connect(this, &PhVideoEngine::decodeFrame, decoder, &PhVideoDecoder::decodeFrame);
 	connect(this, &PhVideoEngine::openInDecoder, decoder, &PhVideoDecoder::open);
 	connect(this, &PhVideoEngine::closeInDecoder, decoder, &PhVideoDecoder::close);
 	connect(decoder, &PhVideoDecoder::frameAvailable, this, &PhVideoEngine::frameAvailable);
-	decoderThread.start();
+	_decoderThread.start();
 }
 
 bool PhVideoEngine::ready()
@@ -275,8 +275,8 @@ PhVideoEngine::~PhVideoEngine()
 {
 	close();
 
-	decoderThread.quit();
-	decoderThread.wait();
+	_decoderThread.quit();
+	_decoderThread.wait();
 
 	// the decoder thread has exited, so all the buffers can be cleaned.
 	while (!_rgbBufferList.isEmpty())

--- a/libs/PhVideo/PhVideoEngine.cpp
+++ b/libs/PhVideo/PhVideoEngine.cpp
@@ -46,8 +46,12 @@ bool PhVideoEngine::ready()
 void PhVideoEngine::setDeinterlace(bool deinterlace)
 {
 	PHDEBUG << deinterlace;
-	_deinterlace = deinterlace;
-	_currentTime = PHTIMEMIN;
+
+	if (deinterlace != _deinterlace) {
+		_deinterlace = deinterlace;
+		// request the frame again to apply the deinterlace settings
+		requestFrame(_currentTime);
+	}
 }
 
 bool PhVideoEngine::bilinearFiltering()
@@ -63,7 +67,11 @@ void PhVideoEngine::setBilinearFiltering(bool bilinear)
 bool PhVideoEngine::open(QString fileName)
 {
 	close();
+
 	PHDEBUG << fileName;
+
+	// tell the decoder thread to open the file too
+	emit openInDecoder(fileName);
 
 	_clock.setTime(0);
 	_clock.setRate(0);
@@ -152,15 +160,15 @@ bool PhVideoEngine::open(QString fileName)
 
 	_fileName = fileName;
 
-	// tell the decoder thread to open the file too
-	emit openInDecoder(fileName);
-
 	return true;
 }
 
 void PhVideoEngine::close()
 {
 	PHDEBUG << _fileName;
+
+	// tell the decoder thread to close the file too
+	emit closeInDecoder();
 
 	// delete all unused buffers
 	// Those that are marked as used should not be deleted for now since the decoder thread may be
@@ -188,9 +196,6 @@ void PhVideoEngine::close()
 	PHDEBUG << _fileName << "closed";
 
 	_fileName = "";
-
-	// tell the decoder thread to close the file too
-	emit closeInDecoder();
 }
 
 void PhVideoEngine::drawVideo(int x, int y, int w, int h)
@@ -202,41 +207,7 @@ void PhVideoEngine::drawVideo(int x, int y, int w, int h)
 	// request that frame to the decoder thread by sending a signal.
 	// The engine manages the frame buffers.
 	if(!isFrameAvailable(time)) {
-		int frameHeight = _videoStream->codec->height;
-		if(_deinterlace)
-			frameHeight = frameHeight / 2;
-		int bufferSize = avpicture_get_size(AV_PIX_FMT_BGRA, _videoStream->codec->width, frameHeight);
-
-		// find an available buffer
-		uint8_t * rgb;
-		int bufferIndex = _bufferUsageList.indexOf(false);
-
-		if(bufferIndex != -1) {
-			// we can reuse an existing available buffer
-			rgb = _rgbBufferList.at(bufferIndex);
-
-			if (_bufferSizeList.at(bufferIndex) != bufferSize) {
-				// the size has changed, update the buffer
-				delete[] rgb;
-				rgb = new uint8_t[bufferSize];
-				_rgbBufferList.replace(bufferIndex, rgb);
-				_bufferSizeList.replace(bufferIndex, bufferSize);
-			}
-		}
-		else {
-			// no buffer is currently available, we need a new one
-			rgb = new uint8_t[bufferSize];
-			_rgbBufferList.append(rgb);
-			_bufferUsageList.append(true);
-			_bufferSizeList.append(bufferSize);
-		}
-
-		// ask the frame to the decoder.
-		// Notice that the time origin for the decoder is 0 at the start of the file, it's not timeIn.
-		emit decodeFrame(time - _timeIn, rgb, _deinterlace);
-
-		// update current time so that we do not request the frame again
-		_currentTime = time;
+		requestFrame(time);
 	}
 
 	// draw whatever frame we currently have
@@ -246,6 +217,45 @@ void PhVideoEngine::drawVideo(int x, int y, int w, int h)
 		_videoRect.setRect(x, y, w, h);
 	_videoRect.setZ(-10);
 	_videoRect.draw();
+}
+
+void PhVideoEngine::requestFrame(PhTime time)
+{
+	int frameHeight = _videoStream->codec->height;
+	if(_deinterlace)
+		frameHeight = frameHeight / 2;
+	int bufferSize = avpicture_get_size(AV_PIX_FMT_BGRA, _videoStream->codec->width, frameHeight);
+
+	// find an available buffer
+	uint8_t * rgb;
+	int bufferIndex = _bufferUsageList.indexOf(false);
+
+	if(bufferIndex != -1) {
+		// we can reuse an existing available buffer
+		rgb = _rgbBufferList.at(bufferIndex);
+
+		if (_bufferSizeList.at(bufferIndex) != bufferSize) {
+			// the size has changed, update the buffer
+			delete[] rgb;
+			rgb = new uint8_t[bufferSize];
+			_rgbBufferList.replace(bufferIndex, rgb);
+			_bufferSizeList.replace(bufferIndex, bufferSize);
+		}
+	}
+	else {
+		// no buffer is currently available, we need a new one
+		rgb = new uint8_t[bufferSize];
+		_rgbBufferList.append(rgb);
+		_bufferUsageList.append(true);
+		_bufferSizeList.append(bufferSize);
+	}
+
+	// ask the frame to the decoder.
+	// Notice that the time origin for the decoder is 0 at the start of the file, it's not timeIn.
+	emit decodeFrame(time - _timeIn, rgb, _deinterlace);
+
+	// update current time so that we do not request the frame again
+	_currentTime = time;
 }
 
 void PhVideoEngine::setTimeIn(PhTime timeIn)
@@ -343,18 +353,17 @@ bool PhVideoEngine::isFrameAvailable(PhTime time)
 	return result;
 }
 
-void PhVideoEngine::frameAvailable(PhTime, uint8_t *rgb, int width, int height)
+void PhVideoEngine::frameAvailable(PhTime time, uint8_t *rgb, int width, int height)
 {
 	// This slot is connected to the decoder thread.
 	// We receive here asynchronously the frame freshly decoded.
 
-	_videoRect.createTextureFromBGRABuffer(rgb, width, height);
-
-	_videoFrameTickCounter.tick();
-
 	// mark that this buffer is now available
 	int bufferIndex = _rgbBufferList.indexOf(rgb);
 	_bufferUsageList.replace(bufferIndex, false);
+
+	_videoRect.createTextureFromBGRABuffer(rgb, width, height);
+	_videoFrameTickCounter.tick();
 }
 
 int64_t PhVideoEngine::PhTime_to_AVTimestamp(PhTime time)

--- a/libs/PhVideo/PhVideoEngine.cpp
+++ b/libs/PhVideo/PhVideoEngine.cpp
@@ -165,8 +165,7 @@ void PhVideoEngine::close()
 	// delete all unused buffers
 	// Those that are marked as used should not be deleted for now since the decoder thread may be
 	// operating on them.
-	while (_bufferUsageList.contains(false))
-	{
+	while (_bufferUsageList.contains(false)) {
 		int unusedBufferIndex = _bufferUsageList.indexOf(false);
 		delete[] _rgbBufferList.takeAt(unusedBufferIndex);
 		_bufferSizeList.removeAt(unusedBufferIndex);
@@ -223,7 +222,8 @@ void PhVideoEngine::drawVideo(int x, int y, int w, int h)
 				_rgbBufferList.replace(bufferIndex, rgb);
 				_bufferSizeList.replace(bufferIndex, bufferSize);
 			}
-		} else {
+		}
+		else {
 			// no buffer is currently available, we need a new one
 			rgb = new uint8_t[bufferSize];
 			_rgbBufferList.append(rgb);
@@ -336,7 +336,7 @@ bool PhVideoEngine::isFrameAvailable(PhTime time)
 	// so it is necessary to use a little margin for the second comparison, otherwise a seek may
 	// be performed on each call to decodeFrame
 	if ((time < _currentTime + PhTimeCode::timePerFrame(_tcType))
-		&& (time > _currentTime - PhTimeCode::timePerFrame(_tcType)/2)) {
+	    && (time > _currentTime - PhTimeCode::timePerFrame(_tcType)/2)) {
 		result = true;
 	}
 

--- a/libs/PhVideo/PhVideoEngine.cpp
+++ b/libs/PhVideo/PhVideoEngine.cpp
@@ -221,6 +221,10 @@ void PhVideoEngine::drawVideo(int x, int y, int w, int h)
 
 void PhVideoEngine::requestFrame(PhTime time)
 {
+	if(!ready()) {
+		return;
+	}
+
 	int frameHeight = _videoStream->codec->height;
 	if(_deinterlace)
 		frameHeight = frameHeight / 2;

--- a/libs/PhVideo/PhVideoEngine.h
+++ b/libs/PhVideo/PhVideoEngine.h
@@ -223,6 +223,7 @@ signals:
 	void closeInDecoder();
 
 private:
+	void requestFrame(PhTime time);
 	int64_t PhTime_to_AVTimestamp(PhTime time);
 	PhTime AVTimestamp_to_PhTime(int64_t timestamp);
 

--- a/libs/PhVideo/PhVideoEngine.h
+++ b/libs/PhVideo/PhVideoEngine.h
@@ -190,11 +190,11 @@ public slots:
 	/**
 	 * @brief Handle a frame that has just been decoded
 	 * @param time the time of the decoded frame (with origin at the start of video file)
-	 * @param rgbBuffer the buffer where the decoded frame is
+	 * @param rgb the buffer where the decoded frame is
 	 * @param width the width of the frame
 	 * @param height the height of the frame
 	 */
-	void frameAvailable(PhTime, uint8_t *rgb, int width, int height);
+	void frameAvailable(PhTime time, uint8_t *rgb, int width, int height);
 
 signals:
 	/**
@@ -206,7 +206,7 @@ signals:
 	/**
 	 * @brief Signal sent to ask the decoder to decode a video frame
 	 * @param time the time of the requested frame (with origin at the start of video file)
-	 * @param rgbBuffer the buffer where to output the decoded frame
+	 * @param rgb the buffer where to output the decoded frame
 	 * @param deinterlace whether the frame is to be deinterlaced
 	 */
 	void decodeFrame(PhTime time, uint8_t *rgb, bool deinterlace);

--- a/libs/PhVideo/PhVideoEngine.h
+++ b/libs/PhVideo/PhVideoEngine.h
@@ -250,7 +250,7 @@ private:
 	QList<bool> _bufferUsageList;
 	QList<int> _bufferSizeList;
 
-	QThread decoderThread;
+	QThread _decoderThread;
 };
 
 #endif // PHVIDEOENGINE_H

--- a/libs/PhVideo/PhVideoEngine.h
+++ b/libs/PhVideo/PhVideoEngine.h
@@ -18,7 +18,6 @@ extern "C" {
 #include <libavformat/avformat.h>
 #include <libavutil/avutil.h>
 #include <libavcodec/avcodec.h>
-#include <libswscale/swscale.h>
 }
 
 #include "PhSync/PhClock.h"
@@ -180,6 +179,23 @@ public:
 	 */
 	void drawVideo(int x, int y, int w, int h);
 
+	/**
+	 * @brief whether the time corresponds to the frame that we currently have (or that we have requested)
+	 * @param time the current time
+	 * @return True if the frame is available
+	 */
+	bool isFrameAvailable(PhTime time);
+
+public slots:
+	/**
+	 * @brief Handle a frame that has just been decoded
+	 * @param time the time of the decoded frame (with origin at the start of video file)
+	 * @param rgbBuffer the buffer where the decoded frame is
+	 * @param width the width of the frame
+	 * @param height the height of the frame
+	 */
+	void frameAvailable(PhTime, uint8_t *rgb, int width, int height);
+
 signals:
 	/**
 	 * @brief Signal sent upon a different timecode type message
@@ -187,8 +203,26 @@ signals:
 	 */
 	void timeCodeTypeChanged(PhTimeCodeType tcType);
 
+	/**
+	 * @brief Signal sent to ask the decoder to decode a video frame
+	 * @param time the time of the requested frame (with origin at the start of video file)
+	 * @param rgbBuffer the buffer where to output the decoded frame
+	 * @param deinterlace whether the frame is to be deinterlaced
+	 */
+	void decodeFrame(PhTime time, uint8_t *rgb, bool deinterlace);
+
+	/**
+	 * @brief Signal sent to the decoder to open a video file
+	 * @param fileName A video file path
+	 */
+	void openInDecoder(QString fileName);
+
+	/**
+	 * @brief Signal sent to the decoder to close the file
+	 */
+	void closeInDecoder();
+
 private:
-	bool decodeFrame(PhTime time);
 	int64_t PhTime_to_AVTimestamp(PhTime time);
 	PhTime AVTimestamp_to_PhTime(int64_t timestamp);
 
@@ -200,8 +234,6 @@ private:
 
 	AVFormatContext * _formatContext;
 	AVStream *_videoStream;
-	AVFrame * _videoFrame;
-	struct SwsContext * _swsContext;
 	PhGraphicTexturedRect _videoRect;
 	PhTime _currentTime;
 
@@ -213,7 +245,11 @@ private:
 
 	bool _deinterlace;
 
-	uint8_t * _rgb;
+	QList<uint8_t *> _rgbBufferList;
+	QList<bool> _bufferUsageList;
+	QList<int> _bufferSizeList;
+
+	QThread decoderThread;
 };
 
 #endif // PHVIDEOENGINE_H

--- a/specs/VideoSpec/VideoSpec.cpp
+++ b/specs/VideoSpec/VideoSpec.cpp
@@ -68,24 +68,25 @@ go_bandit([](){
 		it("go_to_01", [&](){
 			AssertThat(engine->open("interlace_%03d.bmp"), IsTrue());
 
-			QThread::msleep(FRAME_WAIT_TIME);
+			QTest::qWait(FRAME_WAIT_TIME);
 			QImage result = view->renderPixmap(64, 64).toImage();
 			result.save("result.bmp");
+
 			AssertThat(result == QImage("interlace_000.bmp"), IsTrue());
 
 			engine->clock()->setFrame(20, PhTimeCodeType25);
 
-			QThread::msleep(FRAME_WAIT_TIME);
+			QTest::qWait(FRAME_WAIT_TIME);
 			AssertThat(view->renderPixmap(64, 64).toImage() == QImage("interlace_020.bmp"), IsTrue());
 
 			engine->clock()->setFrame(100, PhTimeCodeType25);
 
-			QThread::msleep(FRAME_WAIT_TIME);
+			QTest::qWait(FRAME_WAIT_TIME);
 			AssertThat(view->renderPixmap(64, 64).toImage() == QImage("interlace_100.bmp"), IsTrue());
 
 			engine->clock()->setFrame(75, PhTimeCodeType25);
 
-			QThread::msleep(FRAME_WAIT_TIME);
+			QTest::qWait(FRAME_WAIT_TIME);
 			AssertThat(view->renderPixmap(64, 64).toImage() == QImage("interlace_075.bmp"), IsTrue());
 		});
 
@@ -94,14 +95,14 @@ go_bandit([](){
 
 			engine->clock()->setFrame(100, PhTimeCodeType25);
 
-			QThread::msleep(FRAME_WAIT_TIME);
+			QTest::qWait(FRAME_WAIT_TIME);
 			AssertThat(view->renderPixmap(64, 64).toImage() == QImage("interlace_100.bmp"), IsTrue());
 
 			engine->clock()->setFrame(99, PhTimeCodeType25);
 
 			PHDEBUG << "second paint";
 
-			QThread::msleep(FRAME_WAIT_TIME);
+			QTest::qWait(FRAME_WAIT_TIME);
 			AssertThat(view->renderPixmap(64, 64).toImage() == QImage("interlace_099.bmp"), IsTrue());
 
 			for(int i = 75; i >= 50; i--) {
@@ -109,7 +110,7 @@ go_bandit([](){
 
 				qDebug() << "Set frame :" << i;
 
-				QThread::msleep(FRAME_WAIT_TIME);
+				QTest::qWait(FRAME_WAIT_TIME);
 				QString name = QString("interlace_%1.bmp").arg(i, 3, 10, QChar('0'));
 				AssertThat(view->renderPixmap(64, 64).toImage() == QImage(name), IsTrue());
 			}
@@ -132,7 +133,7 @@ go_bandit([](){
 				PhFrame frame = list[i];
 				engine->clock()->setFrame(frame, PhTimeCodeType25);
 
-				QThread::msleep(FRAME_WAIT_TIME);
+				QTest::qWait(FRAME_WAIT_TIME);
 				QString name = QString("interlace_%1.bmp").arg(frame, 3, 10, QChar('0'));
 				AssertThat(compareImage(view->renderPixmap(64, 64).toImage(), QImage(name), "go_to_03"), IsTrue());
 			}
@@ -141,33 +142,33 @@ go_bandit([](){
 		it("play", [&](){
 			AssertThat(engine->open("interlace_%03d.bmp"), IsTrue());
 
-			QThread::msleep(FRAME_WAIT_TIME);
+			QTest::qWait(FRAME_WAIT_TIME);
 			AssertThat(view->renderPixmap(64, 64).toImage() == QImage("interlace_000.bmp"), IsTrue());
 
 			engine->clock()->setRate(1);
 			engine->clock()->elapse(960); // 1 frame at 25 fps
 
-			QThread::msleep(FRAME_WAIT_TIME);
+			QTest::qWait(FRAME_WAIT_TIME);
 			AssertThat(view->renderPixmap(64, 64).toImage() == QImage("interlace_001.bmp"), IsTrue());
 
 
 			// Play 1 second
 			for(int i = 0; i < 25; i++) {
 				engine->clock()->elapse(960); // 1 frame at 25 fps
-				QThread::msleep(FRAME_WAIT_TIME);
+				QTest::qWait(FRAME_WAIT_TIME);
 			}
 
 			AssertThat(view->renderPixmap(64, 64).toImage() == QImage("interlace_026.bmp"), IsTrue());
 
 			engine->clock()->setRate(-1);
 			engine->clock()->elapse(960); // 1 frame at 25 fps
-			QThread::msleep(FRAME_WAIT_TIME);
+			QTest::qWait(FRAME_WAIT_TIME);
 			AssertThat(view->renderPixmap(64, 64).toImage() == QImage("interlace_025.bmp"), IsTrue());
 
 			// Play 1 second
 			for(int i = 24; i >= 0; i--) {
 				engine->clock()->elapse(960); // 1 frame at 25 fps
-				QThread::msleep(FRAME_WAIT_TIME);
+				QTest::qWait(FRAME_WAIT_TIME);
 			}
 			AssertThat(view->renderPixmap(64, 64).toImage() == QImage("interlace_000.bmp"), IsTrue());
 		});
@@ -175,29 +176,29 @@ go_bandit([](){
 		it("deinterlace", [&](){
 			// Open the video file in interlaced mode
 			engine->open("interlace_%03d.bmp");
-			QThread::msleep(FRAME_WAIT_TIME);
+			QTest::qWait(FRAME_WAIT_TIME);
 			AssertThat(view->renderPixmap(64, 64).toImage() == QImage("interlace_000.bmp"), IsTrue());
 
 			//Change mode to deinterlaced
 			engine->setDeinterlace(true);
-			QThread::msleep(FRAME_WAIT_TIME);
+			QTest::qWait(FRAME_WAIT_TIME);
 			AssertThat(view->renderPixmap(64, 64).toImage() == QImage("deinterlace_000.bmp"), IsTrue());
 
 			//Move one picture forward
 			engine->clock()->setFrame(1, PhTimeCodeType25);
-			QThread::msleep(FRAME_WAIT_TIME);
+			QTest::qWait(FRAME_WAIT_TIME);
 			AssertThat(view->renderPixmap(64, 64).toImage() == QImage("deinterlace_001.bmp"), IsTrue());
 
 			// Go back to interlaced mode
 			engine->setDeinterlace(false);
-			QThread::msleep(FRAME_WAIT_TIME);
+			QTest::qWait(FRAME_WAIT_TIME);
 			AssertThat(view->renderPixmap(64, 64).toImage() == QImage("interlace_001.bmp"), IsTrue());
 		});
 
 		it("scales", [&](){
 			// Open the video file in interlaced mode
 			engine->open("interlace_%03d.bmp");
-			QThread::msleep(FRAME_WAIT_TIME);
+			QTest::qWait(FRAME_WAIT_TIME);
 
 			factor = 2;
 
@@ -209,7 +210,7 @@ go_bandit([](){
 		it("doesn't scale when using native video size", [&](){
 			// Open the video file in interlaced mode
 			engine->open("interlace_%03d.bmp");
-			QThread::msleep(FRAME_WAIT_TIME);
+			QTest::qWait(FRAME_WAIT_TIME);
 
 			factor = 2;
 

--- a/specs/VideoSpec/VideoSpec.cpp
+++ b/specs/VideoSpec/VideoSpec.cpp
@@ -11,7 +11,7 @@
 
 #include "VideoSpecSettings.h"
 
-#define FRAME_WAIT_TIME 40
+#define FRAME_WAIT_TIME 80
 
 #include "PhSpec.h"
 #include "CommonSpec.h"


### PR DESCRIPTION
Hi Martin,

This PR is about making the video engine work asynchronously. The file is opened in a decoder class that runs in a separate thread, and signal and slots are used to request the frame asynchronously.

In order to limit the mutlithreading complexity, I have chosen to let _both_ the engine and the decoder classes open the video file. It avoids using mutexes or other synchronisation systems to protect variables between threads. There is just a simple buffer management mechanism to avoid reallocating the rgb buffer on each frame.

On my machine, about one third of Joker CPU time ends up in the separate thread.

Compared the existing PR #242, it does not read any frame in advance.

I hope this will bring a little bit of additional smoothness to Joker :)

Best regards,

Timothée