### PR TITLE
Tl warnings

### DIFF
--- a/libs/PhCommonUI/PhDocumentWindow.cpp
+++ b/libs/PhCommonUI/PhDocumentWindow.cpp
@@ -78,6 +78,8 @@ bool PhDocumentWindow::eventFilter(QObject *sender, QEvent *event)
 			}
 			break;
 		}
+	default:
+		break;
 	}
 
 	return PhWindow::eventFilter(sender, event);

--- a/libs/PhMidi/PhMidiInput.cpp
+++ b/libs/PhMidi/PhMidiInput.cpp
@@ -26,16 +26,14 @@ QStringList PhMidiInput::inputList()
 {
 	QStringList result;
 
-	RtMidiIn *midiIn;
 	try {
-		midiIn = new RtMidiIn();
+		QScopedPointer<RtMidiIn> midiIn;
 		for(unsigned int i = 0; i < midiIn->getPortCount(); i++)
 			result.append(QString::fromStdString(midiIn->getPortName(i)));
 	}
 	catch(RtMidiError &error) {
 		PHDEBUG << "Midi error:" << QString::fromStdString(error.getMessage());
 	}
-	delete midiIn;
 
 	return result;
 }

--- a/libs/PhMidi/PhMidiObject.cpp
+++ b/libs/PhMidi/PhMidiObject.cpp
@@ -15,9 +15,8 @@ PhMidiObject::PhMidiObject() :
 bool PhMidiObject::canUseVirtualPorts()
 {
 	bool result = false;
-	RtMidiOut *midiOut;
 	try {
-		midiOut = new RtMidiOut();
+		QScopedPointer<RtMidiOut> midiOut;
 
 		RtMidi::Api midiApi = midiOut->getCurrentApi();
 
@@ -30,7 +29,6 @@ bool PhMidiObject::canUseVirtualPorts()
 	catch(RtMidiError &error) {
 		PHDEBUG << "Midi error:" << QString::fromStdString(error.getMessage());
 	}
-	delete midiOut;
 
 	return result;
 }

--- a/libs/PhMidi/PhMidiObject.cpp
+++ b/libs/PhMidi/PhMidiObject.cpp
@@ -65,6 +65,7 @@ unsigned char PhMidiObject::computeHH(unsigned char hh, PhTimeCodeType tcType)
 	case PhTimeCodeType30:
 		return hh | (3 << 5);
 	}
+	return 0;
 }
 
 unsigned char PhMidiObject::computeH(unsigned char hh, PhTimeCodeType tcType)

--- a/libs/PhMidi/PhMidiOutput.cpp
+++ b/libs/PhMidi/PhMidiOutput.cpp
@@ -20,16 +20,14 @@ PhMidiOutput::~PhMidiOutput()
 QStringList PhMidiOutput::outputList()
 {
 	QStringList result;
-	RtMidiOut *midiOut;
 	try {
-		midiOut = new RtMidiOut();
+		QScopedPointer<RtMidiOut> midiOut;
 		for(unsigned int i = 0; i < midiOut->getPortCount(); i++)
 			result.append(QString::fromStdString(midiOut->getPortName(i)));
 	}
 	catch(RtMidiError &error) {
 		PHDEBUG << "Midi error:" << QString::fromStdString(error.getMessage());
 	}
-	delete midiOut;
 
 	return result;
 }

--- a/libs/PhSync/PhTimeCode.cpp
+++ b/libs/PhSync/PhTimeCode.cpp
@@ -235,7 +235,7 @@ PhFrame PhTimeCode::frameFromHhMmSsFf(unsigned int hh, unsigned int mm, unsigned
 		PHDEBUG << "Bad second value:" << QString::number(ss);
 		ss = 0;
 	}
-	if (ff >= fps) {
+	if ((long) ff >= fps) {
 		PHDEBUG << "Bad frame value:" << QString::number(ff);
 		ff = 0;
 	}

--- a/libs/PhSync/PhTimeCode.cpp
+++ b/libs/PhSync/PhTimeCode.cpp
@@ -96,6 +96,7 @@ PhFrame PhTimeCode::getFps(PhTimeCodeType type) {
 	case PhTimeCodeType30:
 		return 30;
 	}
+	return 0;
 }
 
 float PhTimeCode::getAverageFps(PhTimeCodeType type)
@@ -112,6 +113,7 @@ float PhTimeCode::getAverageFps(PhTimeCodeType type)
 	case PhTimeCodeType30:
 		return 30;
 	}
+	return 0;
 }
 
 PhTimeCodeType PhTimeCode::computeTimeCodeType(float averageFps)
@@ -150,6 +152,7 @@ PhTime PhTimeCode::timePerFrame(PhTimeCodeType type)
 	case PhTimeCodeType30:
 		return 800;
 	}
+	return 0;
 }
 
 PhTime PhTimeCode::timeFromString(QString string, PhTimeCodeType type)

--- a/libs/PhTools/PhDebug.cpp
+++ b/libs/PhTools/PhDebug.cpp
@@ -163,21 +163,3 @@ int PhDebug::logMask()
 {
 	return instance()->_logMask;
 }
-
-QDebug operator <<(QDebug stream, const QEvent * event) {
-	static int eventEnumIndex = QEvent::staticMetaObject
-	                            .indexOfEnumerator("Type");
-	stream << "QEvent";
-	if (event) {
-		QString name = QEvent::staticMetaObject
-		               .enumerator(eventEnumIndex).valueToKey(event->type());
-		if (!name.isEmpty())
-			stream << PHNQ(name);
-		else
-			stream << event->type();
-	}
-	else {
-		stream << (void*)event;
-	}
-	return stream;
-}

--- a/libs/PhTools/PhDebug.h
+++ b/libs/PhTools/PhDebug.h
@@ -166,12 +166,4 @@ private:
 
 };
 
-/**
- * @brief Gives human-readable event type information
- * @param stream The debug stream
- * @param event The event
- * @return The new debug stream
- */
-QDebug operator <<(QDebug stream, const QEvent * event);
-
 #endif // PHDEBUG_H

--- a/specs/ToolsSpec/DebugSpec.cpp
+++ b/specs/ToolsSpec/DebugSpec.cpp
@@ -91,14 +91,6 @@ go_bandit([](){
 			PhDebug::enable();
 			PHDEBUG << "shown because enable()";
 
-			QEvent * event = NULL;
-			PHDEBUG << event;
-			event = new QMouseEvent(QEvent::MouseButtonPress, QPoint(0, 0), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
-			PHDEBUG << event;
-			delete event;
-			event = new QEvent((QEvent::Type)999);
-			PHDEBUG << event;
-
 			AssertThat(PhDebug::logMask(), Equals(1));
 			PHDBG(0) << "it should be displayed when default log mask is 1";
 			int testLogLevel = 31;
@@ -108,17 +100,14 @@ go_bandit([](){
 			PHDBG(testLogLevel) << "it should be displayed when default log mask is " + testLogLevel;
 
 			QStringList lines = QString::fromStdString(buffer.str()).split("\n");
-			AssertThat(lines.count(), Equals(10));
+			AssertThat(lines.count(), Equals(7));
 			AssertThat(QRegExp("\\d\\d/\\d\\d/\\d\\d\\d\\d \\d\\d:\\d\\d:\\d\\d\\.\\d\\d\\d DebugSpec.cpp\toperator\\(\\)\t@[0-9]+\ttest with all log parameters").exactMatch(lines[0]), IsTrue());
 
 			AssertThat(lines[1].toStdString(), Equals("test with no log parameters"));
 			AssertThat(lines[2].toStdString(), Equals("shown because of showConsole(true)"));
 			AssertThat(lines[3].toStdString(), Equals("shown because enable()"));
-			AssertThat(lines[4].toStdString(), Equals("QEvent 0x0"));
-			AssertThat(lines[5].toStdString(), Equals("QEvent MouseButtonPress"));
-			AssertThat(lines[6].toStdString(), Equals("QEvent 999"));
-			AssertThat(lines[7].toStdString(), Equals("it should be displayed when default log mask is 1"));
-			AssertThat(lines[8].toStdString(), Equals("it should be displayed when default log mask is " + testLogLevel));
+			AssertThat(lines[4].toStdString(), Equals("it should be displayed when default log mask is 1"));
+			AssertThat(lines[5].toStdString(), Equals("it should be displayed when default log mask is " + testLogLevel));
 		});
 
 		it("display_in_the_error", []() {


### PR DESCRIPTION
Hi Martin,

This PR is about removing some compiler warnings.

Nothing special, apart from the removal of the QDebug << operator overloading for QEvents. On WIndows it produces a large number of warnings about a missing dllimport. I could not find a way to fix it, but it seems to me that it was not used anywhere, so I removed it altogether.

Thanks,

Timothée