### PR TITLE
Font and scrolling fix

### DIFF
--- a/app/Joker/JokerSettings.h
+++ b/app/Joker/JokerSettings.h
@@ -99,8 +99,8 @@ public:
 #ifdef USE_VIDEO
 	// Video settings:
 	PH_SETTING_BOOL(setUseNativeVideoSize, useNativeVideoSize)
-	PH_SETTING_INT2(setVideoReadhead, videoReadhead, 50)
-	PH_SETTING_FRAME2(setVideoPoolSize, videoPoolSize, 120)
+	PH_SETTING_INT2(setVideoReadhead, videoReadhead, 10)
+	PH_SETTING_FRAME2(setVideoPoolSize, videoPoolSize, 20)
 
 	PH_SETTING_BOOL(setVideoPictureInPicture, videoPictureInPicture)
 	PH_SETTING_INT2(setVideoPictureInPictureOffset, videoPictureInPictureOffset, 1000)

--- a/libs/PhGraphic/PhFont.cpp
+++ b/libs/PhGraphic/PhFont.cpp
@@ -13,7 +13,7 @@
 #include "PhFont.h"
 #include "PhTools/PhDebug.h"
 
-PhFont::PhFont() : _texture(-1), _glyphHeight(0), _weight(400), _ready(false)
+PhFont::PhFont() : _texture(-1), _glyphHeight(0), _weight(99), _ready(false)
 {
 	for(int ch = 0; ch < 256; ++ch) {
 		_glyphAdvance[ch] = 0;
@@ -177,6 +177,14 @@ int PhFont::getNominalWidth(QString string)
 void PhFont::setWeight(int weight)
 {
 	if(_weight != weight) {
+		if (weight > 99) {
+			weight = 99;
+		}
+
+		if (weight < 0) {
+			weight = 0;
+		}
+
 		_weight = weight;
 		_ready = false;
 	}

--- a/libs/PhVideo/PhVideoDecoder.h
+++ b/libs/PhVideo/PhVideoDecoder.h
@@ -60,16 +60,6 @@ public slots:
 	void close();
 
 	/**
-	 * @brief Start the decoder processing loop
-	 */
-	void process();
-
-	/**
-	 * @brief Stop the decoder processing loop
-	 */
-	void stop();
-
-	/**
 	 * @brief Decode the next requested frame
 	 */
 	void decodeFrame();
@@ -147,7 +137,7 @@ private:
 	AVStream *_audioStream;
 	AVFrame * _audioFrame;
 
-	bool _deinterlace, _processing;
+	bool _deinterlace;
 
 	QList<PhVideoBuffer *> _requestedFrames;
 };

--- a/libs/PhVideo/PhVideoEngine.cpp
+++ b/libs/PhVideo/PhVideoEngine.cpp
@@ -30,8 +30,6 @@ PhVideoEngine::PhVideoEngine(PhVideoSettings *settings) :
 	PhVideoDecoder *decoder = new PhVideoDecoder();
 	decoder->moveToThread(&_decoderThread);
 	connect(&_clock, &PhClock::timeChanged, this, &PhVideoEngine::onTimeChanged);
-	connect(&_decoderThread, &QThread::started, decoder, &PhVideoDecoder::process);
-	connect(this, &PhVideoEngine::stopDecoder, decoder, &PhVideoDecoder::stop);
 	connect(&_decoderThread, &QThread::finished, decoder, &QObject::deleteLater);
 	connect(&_framePool, &PhVideoPool::decodeFrame, decoder, &PhVideoDecoder::requestFrame);
 	connect(this, &PhVideoEngine::openInDecoder, decoder, &PhVideoDecoder::open);

--- a/specs/ToolsSpec/DebugSpec.cpp
+++ b/specs/ToolsSpec/DebugSpec.cpp
@@ -3,6 +3,8 @@
  * License: http://www.gnu.org/licenses/gpl.html GPL version 2 or higher
  */
 
+#include <QDir>
+
 #include "PhTools/PhDebug.h"
 
 #include "CommonSpec.h"


### PR DESCRIPTION
Hello Martin,

This PR contains a fix for the scrolling issue #398. This is mostly 2 things: avoiding the 5 ms lag in the process loop, and reducing the pool size.

It also contains 2 fixes for issues I've got (maybe only on Windows - Qt 5.4): font weight cannot be larger than 99, and a QDir include was missing.

Thanks!