### PR TITLE
Performance improvement in the video engine

### DIFF
--- a/app/Joker/JokerSettings.h
+++ b/app/Joker/JokerSettings.h
@@ -100,7 +100,7 @@ public:
 	// Video settings:
 	PH_SETTING_BOOL(setUseNativeVideoSize, useNativeVideoSize)
 	PH_SETTING_INT2(setVideoReadhead, videoReadhead, 50)
-	PH_SETTING_FRAME2(setVideoPoolSize, videoPoolSize, 120)
+	PH_SETTING_FRAME2(setVideoPoolSize, videoPoolSize, 240)
 
 	PH_SETTING_BOOL(setVideoPictureInPicture, videoPictureInPicture)
 	PH_SETTING_INT2(setVideoPictureInPictureOffset, videoPictureInPictureOffset, 1000)

--- a/libs/PhVideo/PhVideoBuffer.cpp
+++ b/libs/PhVideo/PhVideoBuffer.cpp
@@ -9,7 +9,6 @@
 PhVideoBuffer::PhVideoBuffer() :
 	_rgb(NULL),
 	_size(0),
-	_requestFrame(0),
 	_frame(0),
 	_width(0),
 	_height(0)
@@ -48,11 +47,6 @@ PhFrame PhVideoBuffer::frame()
 	return _frame;
 }
 
-PhFrame PhVideoBuffer::requestFrame()
-{
-	return _requestFrame;
-}
-
 int PhVideoBuffer::width()
 {
 	return _width;
@@ -66,11 +60,6 @@ int PhVideoBuffer::height()
 void PhVideoBuffer::setFrame(PhFrame frame)
 {
 	_frame = frame;
-}
-
-void PhVideoBuffer::setRequestFrame(PhFrame requestFrame)
-{
-	_requestFrame = requestFrame;
 }
 
 void PhVideoBuffer::setWidth(int width)

--- a/libs/PhVideo/PhVideoBuffer.cpp
+++ b/libs/PhVideo/PhVideoBuffer.cpp
@@ -6,6 +6,8 @@
 
 #include "PhVideoBuffer.h"
 
+#include "PhTools/PhDebug.h"
+
 PhVideoBuffer::PhVideoBuffer() :
 	_rgb(NULL),
 	_size(0),
@@ -30,6 +32,7 @@ void PhVideoBuffer::reuse(int size)
 		if (_rgb != NULL) {
 			delete[] _rgb;
 		}
+		PHDBG(24) << "PhVideoBuffer alloc" << size;
 		_size = size;
 		_rgb = new uint8_t[_size];
 	}

--- a/libs/PhVideo/PhVideoBuffer.h
+++ b/libs/PhVideo/PhVideoBuffer.h
@@ -43,12 +43,6 @@ public:
 	PhFrame frame();
 
 	/**
-	 * @brief Gets the request frame number of the buffer (with origin at the start of video file)
-	 * @return The frame number
-	 */
-	PhFrame requestFrame();
-
-	/**
 	 * @brief Gets the width of the buffer
 	 * @return The width of the buffer
 	 */
@@ -67,12 +61,6 @@ public:
 	void setFrame(PhFrame frame);
 
 	/**
-	 * @brief Sets the request frame number of the buffer (with origin at the start of video file)
-	 * @param requestFrame The frame number
-	 */
-	void setRequestFrame(PhFrame requestFrame);
-
-	/**
 	 * @brief Sets the width of the buffer
 	 * @param width The width of the buffer
 	 */
@@ -87,7 +75,6 @@ public:
 private:
 	uint8_t * _rgb;
 	int _size;
-	PhFrame _requestFrame;
 	PhFrame _frame;
 	int _width;
 	int _height;

--- a/libs/PhVideo/PhVideoDecoder.cpp
+++ b/libs/PhVideo/PhVideoDecoder.cpp
@@ -280,7 +280,7 @@ bool PhVideoDecoder::canDecode()
 		return true;
 	}
 
-	return readAheadFrame() > _currentFrame;
+	return readAheadFrame() > _currentFrame + 1;
 }
 
 PhFrame PhVideoDecoder::readAheadFrame()

--- a/libs/PhVideo/PhVideoDecoder.cpp
+++ b/libs/PhVideo/PhVideoDecoder.cpp
@@ -29,7 +29,7 @@ PhVideoDecoder::PhVideoDecoder(PhVideoSettings *settings) :
 	_seek(false),
 	_fastSeek(false),
 	_readAheadCount(settings->videoReadhead()),
-	_maxAllocatedCount(2*settings->videoPoolSize() + settings->videoReadhead()),
+	_maxAllocatedCount(settings->videoPoolSize() + settings->videoReadhead()),
 	_allocatedCount(0),
 	_seekThreshold(settings->videoReadhead())
 {

--- a/libs/PhVideo/PhVideoDecoder.h
+++ b/libs/PhVideo/PhVideoDecoder.h
@@ -138,8 +138,9 @@ private:
 	bool _seek;
 	bool _fastSeek;
 	int _readAheadCount;
-	int _recycledCount;
+	int _maxAllocatedCount;
 	int _seekThreshold;
+	int _allocatedCount;
 
 	bool _useAudio;
 	AVStream *_audioStream;
@@ -149,6 +150,7 @@ private:
 
 	QList<PhVideoBuffer *> _recycledFrames;
 	PhVideoBuffer *getAvailableFrame();
+	bool hasAvailableFrame();
 	PhFrame readAheadFrame();
 	bool canDecode();
 	PhFrame clip(PhFrame frame);

--- a/libs/PhVideo/PhVideoDecoder.h
+++ b/libs/PhVideo/PhVideoDecoder.h
@@ -61,11 +61,6 @@ public slots:
 	void close();
 
 	/**
-	 * @brief Decode the next requested frame
-	 */
-	void decodeFrame();
-
-	/**
 	 * @brief Signal sent when the deinterlace settings change
 	 * @param deinterlace Whether the video should be deinterlaced
 	 */
@@ -123,6 +118,7 @@ private:
 	int height();
 	QString codecName();
 	PhFrame frameIn();
+	void decodeFrame();
 
 	int64_t PhFrame_to_AVTimestamp(PhFrame frame);
 	PhFrame AVTimestamp_to_PhFrame(int64_t timestamp);

--- a/libs/PhVideo/PhVideoDecoder.h
+++ b/libs/PhVideo/PhVideoDecoder.h
@@ -24,6 +24,7 @@ extern "C" {
 #include <QObject>
 
 #include "PhSync/PhTimeCode.h"
+#include "PhVideoSettings.h"
 
 #include "PhVideoBuffer.h"
 
@@ -41,7 +42,7 @@ public:
 	/**
 	 * @brief PhVideoEngine constructor
 	 */
-	explicit PhVideoDecoder();
+	explicit PhVideoDecoder(PhVideoSettings *settings);
 
 	~PhVideoDecoder();
 
@@ -65,35 +66,37 @@ public slots:
 	void decodeFrame();
 
 	/**
-	 * @brief Request a video frame
-	 * @param buffer The requested frame
-	 */
-	void requestFrame(PhVideoBuffer *buffer);
-
-	/**
-	 * @brief cancel a frame request
-	 * @param frame the frame describing the request
-	 */
-	void cancelFrameRequest(PhVideoBuffer *frame);
-
-	/**
 	 * @brief Signal sent when the deinterlace settings change
 	 * @param deinterlace Whether the video should be deinterlaced
 	 */
 	void setDeinterlace(bool deinterlace);
 
+	/**
+	 * @brief inform the decoder that the strip time has changed
+	 * @param stripFrame the new strip frame
+	 * @param backward true if the strip is being played backward
+	 * @param stripFrameIsInPool true if the frame was found in the decoded frame pool
+	 */
+	void stripTimeChanged(PhFrame stripFrame, bool backward, bool stripFrameIsInPool);
+
+	/**
+	 * @brief Stop
+	 *
+	 * Stop the decoder, prevents further decoding (including read-ahead)
+	 */
+	void stop();
+
+	/**
+	 * @brief transfer an unused frame buffer
+	 * @param frame the unused frame buffer
+	 */
+	void recycleFrame(PhVideoBuffer *frame);
 signals:
 	/**
 	 * @brief Signal sent when a frame has been decoded
 	 * @param buffer The frame where the decoded frame is
 	 */
 	void frameAvailable(PhVideoBuffer *buffer);
-
-	/**
-	 * @brief Signal sent when a frame request has been cancelled
-	 * @param frame The frame describing the request
-	 */
-	void frameCancelled(PhVideoBuffer *frame);
 
 	/**
 	 * @brief Signal sent when the decoder is ready
@@ -115,7 +118,7 @@ private:
 	bool ready();
 	double framePerSecond();
 	PhFrame frameLength();
-	void frameToRgb(AVFrame *avFrame, PhVideoBuffer *buffer);
+	void frameToRgb(AVFrame *avFrame);
 	int width();
 	int height();
 	QString codecName();
@@ -132,6 +135,15 @@ private:
 	AVFrame * _videoFrame;
 	struct SwsContext * _swsContext;
 	PhFrame _currentFrame;
+	PhFrame _stripFrame;
+	PhFrame _seekFrame;
+	bool _backward;
+	bool _processing;
+	bool _seek;
+	bool _fastSeek;
+	int _readAheadCount;
+	int _recycledCount;
+	int _seekThreshold;
 
 	bool _useAudio;
 	AVStream *_audioStream;
@@ -139,7 +151,12 @@ private:
 
 	bool _deinterlace;
 
-	QList<PhVideoBuffer *> _requestedFrames;
+	QList<PhVideoBuffer *> _recycledFrames;
+	PhVideoBuffer *getAvailableFrame();
+	PhFrame readAheadFrame();
+	bool canDecode();
+	PhFrame clip(PhFrame frame);
+	void fastForwardToFrame(PhFrame frame);
 };
 
 #endif // PHVIDEODECODER_H

--- a/libs/PhVideo/PhVideoEngine.h
+++ b/libs/PhVideo/PhVideoEngine.h
@@ -173,9 +173,9 @@ public:
 
 	/**
 	 * @brief Pool of decoded frames
-	 * @return A read only list of frames
+	 * @return A read-only map of frames
 	 */
-	const QList<PhVideoBuffer*> decodedFramePool();
+	const QMap<PhFrame, PhVideoBuffer *> decodedFramePool();
 
 public slots:
 	/**
@@ -241,6 +241,13 @@ signals:
 	 * @brief Stop the decoder processing loop
 	 */
 	void stopDecoder();
+
+	/**
+	 * @brief signal sent when the strip time has changed
+	 * @param stripFrame the new strip frame
+	 * @param backward true if the strip is being played backward
+	 */
+	void stripTimeChanged(PhFrame stripFrame, bool backward);
 
 private slots:
 	void onTimeChanged(PhTime);

--- a/libs/PhVideo/PhVideoPool.cpp
+++ b/libs/PhVideo/PhVideoPool.cpp
@@ -67,17 +67,17 @@ void PhVideoPool::frameAvailable(PhVideoBuffer *buffer)
 
 void PhVideoPool::cleanup(PhFrame frame)
 {
-	PhFrame halfPoolSize = _settings->videoPoolSize();
+	PhFrame poolSize = _settings->videoPoolSize();
 
 	if (!_decodedPool.empty()) {
 		PhVideoBuffer * firstFrame = _decodedPool.first();
 		int frameBytes = firstFrame->width()*firstFrame->height()*4;
 
 		// limit to 1 GB of frames
-		halfPoolSize = std::min((int)halfPoolSize, 500000000 / frameBytes);
+		poolSize = std::min((int)poolSize, 1000000000 / frameBytes);
 	}
 
-	int cleanupCount = _decodedPool.size() - 2*halfPoolSize;
+	int cleanupCount = _decodedPool.size() - poolSize;
 
 	if (cleanupCount <= 0) {
 		// no need to cleanup
@@ -95,7 +95,7 @@ void PhVideoPool::cleanup(PhFrame frame)
 			i.next();
 			PhFrame bufferFrame = i.key();
 
-			if ((bufferFrame < frame - halfPoolSize) || (bufferFrame >= frame + halfPoolSize)) {
+			if ((bufferFrame < frame - poolSize) || (bufferFrame >= frame + poolSize)) {
 				// Given the current playing direction and position,
 				// this buffer is not likely to be shown on screen anytime soon.
 				PhVideoBuffer *buffer = i.value();
@@ -114,7 +114,7 @@ void PhVideoPool::cleanup(PhFrame frame)
 			i.previous();
 			PhFrame bufferFrame = i.key();
 
-			if ((bufferFrame < frame - halfPoolSize) || (bufferFrame >= frame + halfPoolSize)) {
+			if ((bufferFrame < frame - poolSize) || (bufferFrame >= frame + poolSize)) {
 				// Given the current playing direction and position,
 				// this buffer is not likely to be shown on screen anytime soon.
 				PhVideoBuffer *buffer = i.value();

--- a/libs/PhVideo/PhVideoPool.cpp
+++ b/libs/PhVideo/PhVideoPool.cpp
@@ -5,79 +5,41 @@
 #include "PhVideoPool.h"
 
 PhVideoPool::PhVideoPool(PhVideoSettings *settings)
-	: _settings(settings), _frameLength(0)
+	: _settings(settings),
+	_frameLength(0),
+	_backward(false),
+	_stripFrame(PHFRAMEMIN)
 {
 
 }
 
-void PhVideoPool::requestFrame(PhFrame frame)
+void PhVideoPool::stripTimeChanged(PhFrame stripFrame, bool backward)
 {
-	PhVideoBuffer * buffer;
-
-	if (!_recycledPool.empty()) {
-		buffer = _recycledPool.takeFirst();
-	}
-	else {
-		PHDBG(24) << "creating a new buffer";
-		buffer = new PhVideoBuffer();
-	}
-
-	buffer->setFrame(0);
-	buffer->setRequestFrame(frame);
-
-	PHDBG(24) << frame;
-
-	// ask the frame to the decoder.
-	// Notice that the time origin for the decoder is 0 at the start of the file, it's not timeIn.
-	emit decodeFrame(buffer);
-
-	_requestedPool.append(buffer);
-}
-
-void PhVideoPool::requestFrames(PhFrame frame, bool backward)
-{
-	PHDBG(24) << frame;
 	if(_frameLength == 0) {
 		PHDBG(24) << "not ready";
 		return;
 	}
 
-	// clip to stream boundaries
-	if(frame < 0)
-		frame = 0;
-	if (frame >= _frameLength)
-		frame = _frameLength;
+	_backward = backward;
+	_stripFrame = stripFrame;
 
-	// we make sure we have requested "readahead_count" frames
-	for (int i = 0; i < _settings->videoReadhead(); i++) {
-		int factor = i;
-		if (backward) {
-			factor *= -1;
-		}
-
-		PhFrame requestedFrame = frame + factor;
-
-		if (!isFrameRequested(requestedFrame)) {
-			requestFrame(requestedFrame);
-		}
-	}
-
-	cleanup(frame);
+	bool isFrameInPool = _decodedPool.contains(stripFrame);
+	emit poolTimeChanged(stripFrame, backward, isFrameInPool);
 }
 
 void PhVideoPool::cancel()
 {
-	foreach(PhVideoBuffer * requestedFrame, _requestedPool) {
-		emit cancelFrameRequest(requestedFrame);
-	}
-	_cancelledPool.append(_requestedPool);
-	_requestedPool.clear();
+	emit stop();
 
-	_recycledPool.append(_decodedPool);
+	foreach(PhVideoBuffer * frame, _decodedPool.values()) {
+		emit recycledFrame(frame);
+	}
+
 	_decodedPool.clear();
+	_stripFrame = PHFRAMEMIN;
 }
 
-const QList<PhVideoBuffer *> PhVideoPool::decoded()
+const QMap<PhFrame, PhVideoBuffer *> PhVideoPool::decoded()
 {
 	return _decodedPool;
 }
@@ -89,105 +51,89 @@ void PhVideoPool::update(PhFrame frameLength)
 
 void PhVideoPool::frameAvailable(PhVideoBuffer *buffer)
 {
-	PHDBG(24) << buffer->requestFrame() << buffer->frame() << buffer->width() << "x" << buffer->height();
-	// move from requested to decoded
-	_cancelledPool.removeAll(buffer);
-	_requestedPool.removeAll(buffer);
-	_decodedPool.append(buffer);
-}
+	PHDBG(24) << buffer->frame() << buffer->width() << "x" << buffer->height();
 
-void PhVideoPool::frameCancelled(PhVideoBuffer *buffer)
-{
-	if (_cancelledPool.contains(buffer)) {
-		_cancelledPool.removeAll(buffer);
-		_recycledPool.append(buffer);
-	}
-}
+	cleanup(_stripFrame);
 
-bool PhVideoPool::isFrameRequested(PhFrame frame)
-{
-	// clip to stream boundaries
-	if(frame < 0)
-		frame = 0;
-	if (frame >= _frameLength)
-		frame = _frameLength;
-
-	QList<PhVideoBuffer *> requestedOrDecodedFrames;
-	requestedOrDecodedFrames.append(_requestedPool);
-	requestedOrDecodedFrames.append(_decodedPool);
-
-	foreach(PhVideoBuffer *requestedBuffer, requestedOrDecodedFrames) {
-		PhFrame requestedFrame = requestedBuffer->requestFrame();
-
-		// We consider that we have requested the frame if the time has changed less
-		// than the time between two frames.
-		if (frame == requestedFrame) {
-			// we have already requested that frame
-			return true;
-		}
+	// remove any existing buffer at that position
+	if (_decodedPool.contains(buffer->frame())) {
+		emit recycledFrame(_decodedPool.take(buffer->frame()));
 	}
 
-	return false;
+	_decodedPool.insert(buffer->frame(), buffer);
 }
 
 void PhVideoPool::cleanup(PhFrame frame)
 {
-	// clip to stream boundaries
-	if(frame < 0)
-		frame = 0;
-	if (frame >= _frameLength)
-		frame = _frameLength;
-
 	PhFrame halfPoolSize = _settings->videoPoolSize();
 
-	QMutableListIterator<PhVideoBuffer*> i(_decodedPool);
-	while (i.hasNext()) {
-		PhVideoBuffer *buffer = i.next();
+	if (!_decodedPool.empty()) {
+		PhVideoBuffer * firstFrame = _decodedPool.first();
+		int frameBytes = firstFrame->width()*firstFrame->height()*4;
 
-		PhFrame bufferFrame = buffer->frame();
-
-		if ((bufferFrame < frame - halfPoolSize) || (bufferFrame >= frame + halfPoolSize)) {
-			// Given the current playing direction and position,
-			// this buffer is not likely to be shown on screen anytime soon.
-			i.remove();
-
-			_recycledPool.append(buffer);
-
-			PHDBG(24) << "recycle buffer " << bufferFrame;
-		}
+		// limit to 1 GB of frames
+		halfPoolSize = std::min((int)halfPoolSize, 500000000 / frameBytes);
 	}
 
-	QMutableListIterator<PhVideoBuffer*> r(_requestedPool);
-	while (r.hasNext()) {
-		PhVideoBuffer *buffer = r.next();
+	int cleanupCount = _decodedPool.size() - 2*halfPoolSize;
 
-		PhFrame bufferFrame = buffer->requestFrame();
-
-		if ((bufferFrame < frame - halfPoolSize) || (bufferFrame >= frame + halfPoolSize)) {
-			// Given the current position,
-			// this frame is not likely to be shown on screen anytime soon.
-			r.remove();
-
-			_cancelledPool.append(buffer);
-
-			// tell the decoder we no longer want this frame to be decoded
-			emit cancelFrameRequest(buffer);
-
-			PHDBG(24) << "cancel frame request " << bufferFrame;
-		}
+	if (cleanupCount <= 0) {
+		// no need to cleanup
+		return;
 	}
 
-	// Make sure we do not have too many recycled frames.
-	// They accumulate when seeking, because there is a short time lag
-	// between the time when the engine asks to cancel a frame and the
-	// time when the decoder really does it.
-	while (_recycledPool.count() > _settings->videoPoolSize()) {
-		PhVideoBuffer * bufferToDelete = _recycledPool.takeFirst();
-		delete bufferToDelete;
+	frame = clip(frame);
+
+	QMutableMapIterator<PhFrame, PhVideoBuffer *> i(_decodedPool);
+
+	if (!_backward) {
+		// QMap.keys is ordered. So, when playing forward, this iterator will work on the older frames first.
+		// So it is likely to clean up enough with the very first iterations
+		while (i.hasNext() && cleanupCount > 0) {
+			i.next();
+			PhFrame bufferFrame = i.key();
+
+			if ((bufferFrame < frame - halfPoolSize) || (bufferFrame >= frame + halfPoolSize)) {
+				// Given the current playing direction and position,
+				// this buffer is not likely to be shown on screen anytime soon.
+				PhVideoBuffer *buffer = i.value();
+				i.remove();
+
+				PHDBG(24) << "recycle buffer " << bufferFrame;
+				emit recycledFrame(buffer);
+
+				cleanupCount--;
+			}
+		}
+	}
+	else {
+		i.toBack();
+		while (i.hasPrevious() && cleanupCount > 0) {
+			i.previous();
+			PhFrame bufferFrame = i.key();
+
+			if ((bufferFrame < frame - halfPoolSize) || (bufferFrame >= frame + halfPoolSize)) {
+				// Given the current playing direction and position,
+				// this buffer is not likely to be shown on screen anytime soon.
+				PhVideoBuffer *buffer = i.value();
+				i.remove();
+
+				PHDBG(24) << "recycle buffer " << bufferFrame;
+				emit recycledFrame(buffer);
+
+				cleanupCount--;
+			}
+		}
 	}
 }
 
-PhVideoBuffer *PhVideoPool::decoded(PhFrame frame)
+PhVideoBuffer *PhVideoPool::tryGetFrame(PhFrame frame)
+{
+	frame = clip(frame);
+	return _decodedPool.value(frame, NULL);
+}
+
+PhFrame PhVideoPool::clip(PhFrame frame)
 {
 	// clip to stream boundaries
 	if(frame < 0)
@@ -195,12 +141,7 @@ PhVideoBuffer *PhVideoPool::decoded(PhFrame frame)
 	if (frame >= _frameLength)
 		frame = _frameLength;
 
-	foreach(PhVideoBuffer *buffer, _decodedPool) {
-		if(frame == buffer->frame())
-			return buffer;
-	}
-
-	return NULL;
+	return frame;
 }
 
 

--- a/libs/PhVideo/PhVideoPool.cpp
+++ b/libs/PhVideo/PhVideoPool.cpp
@@ -23,6 +23,8 @@ void PhVideoPool::stripTimeChanged(PhFrame stripFrame, bool backward)
 	_backward = backward;
 	_stripFrame = stripFrame;
 
+	cleanup(_stripFrame);
+
 	bool isFrameInPool = _decodedPool.contains(stripFrame);
 	emit poolTimeChanged(stripFrame, backward, isFrameInPool);
 }

--- a/specs/VideoSpec/VideoDecoderSpec.cpp
+++ b/specs/VideoSpec/VideoDecoderSpec.cpp
@@ -3,14 +3,17 @@
 #include "PhTools/PhDebug.h"
 #include "PhVideo/PhVideoDecoder.h"
 
+#include "VideoSpecSettings.h"
+
 using namespace bandit;
 
 go_bandit([](){
 	describe("decoder", [](){
 		PhVideoDecoder *decoder;
+		VideoSpecSettings *settings = new VideoSpecSettings();
 
 		before_each([&](){
-			decoder = new PhVideoDecoder();
+			decoder = new PhVideoDecoder(settings);
 		});
 
 		it("succeed", [&](){
@@ -56,35 +59,25 @@ go_bandit([](){
 		it("decode frame", [&](){
 			decoder->open("interlace_%03d.bmp");
 
-			PhVideoBuffer buffer0, buffer1, buffer2;
-			PhVideoBuffer *expectedBuffer = NULL;
 			PhFrame expectedFrame = 0;
 			int frameAvailableCallCount = 0;
 
 			QObject::connect(decoder, &PhVideoDecoder::frameAvailable, [&](PhVideoBuffer *buffer){
-				AssertThat(buffer, Equals(expectedBuffer));
 				AssertThat(buffer->frame(), Equals(expectedFrame));
 				frameAvailableCallCount += 1;
 			});
 
-			expectedBuffer = &buffer0;
-			buffer0.setRequestFrame(0);
-			decoder->requestFrame(&buffer0);
+			decoder->stripTimeChanged(0, false, false);
 			decoder->decodeFrame();
-
 			AssertThat(frameAvailableCallCount, Equals(1));
 
-			expectedBuffer = &buffer1;
-			buffer1.setRequestFrame(1);
 			expectedFrame = 1;
-			decoder->requestFrame(&buffer1);
+			decoder->stripTimeChanged(1, false, false);
 			decoder->decodeFrame();
 			AssertThat(frameAvailableCallCount, Equals(2));
 
-			expectedBuffer = &buffer2;
-			buffer2.setRequestFrame(2);
 			expectedFrame = 2;
-			decoder->requestFrame(&buffer2);
+			decoder->stripTimeChanged(2, false, false);
 			decoder->decodeFrame();
 			AssertThat(frameAvailableCallCount, Equals(3));
 		});

--- a/specs/VideoSpec/VideoSpec.cpp
+++ b/specs/VideoSpec/VideoSpec.cpp
@@ -329,6 +329,11 @@ go_bandit([](){
 				AssertThat(decodeSpy->count(), Equals(5));
 
 				AssertThat(engine->decodedFramePool().count(), Equals(5));
+				AssertThat(engine->decodedFramePool().contains(0), IsTrue());
+				AssertThat(engine->decodedFramePool().contains(1), IsTrue());
+				AssertThat(engine->decodedFramePool().contains(2), IsTrue());
+				AssertThat(engine->decodedFramePool().contains(3), IsTrue());
+				AssertThat(engine->decodedFramePool().contains(4), IsTrue());
 
 				// Add 50 other frame to the pool
 				for(int frame = 1; frame <= 50; frame++) {
@@ -344,14 +349,41 @@ go_bandit([](){
 				AssertThat(decodeSpy->wait(DECODE_WAIT_TIME), IsTrue());
 				AssertThat(decodeSpy->count(), Equals(56));
 				AssertThat(engine->decodedFramePool().count(), Equals(55));
+				AssertThat(engine->decodedFramePool().contains(51), IsTrue());
+				AssertThat(engine->decodedFramePool().contains(52), IsTrue());
+				AssertThat(engine->decodedFramePool().contains(53), IsTrue());
+				AssertThat(engine->decodedFramePool().contains(54), IsTrue());
+				AssertThat(engine->decodedFramePool().contains(55), IsTrue());
+				// pool has discarded the oldest frame
+				AssertThat(engine->decodedFramePool().contains(0), IsFalse());
+				AssertThat(engine->decodedFramePool().contains(1), IsTrue());
 
-				// Jump to a far location clear the pool
+				// Jump to a far location
 				engine->clock()->setFrame25(120);
 				while(decodeSpy->count() < 61) {
 					AssertThat(decodeSpy->wait(DECODE_WAIT_TIME), IsTrue());
 				}
 				AssertThat(decodeSpy->count(), Equals(61));
-				AssertThat(engine->decodedFramePool().count(), Equals(5));
+				// pool is not full anymore, it has discarded the readahead frames
+				AssertThat(engine->decodedFramePool().count(), Equals(51));
+				// pool contains the new frames
+				AssertThat(engine->decodedFramePool().contains(120), IsTrue());
+				AssertThat(engine->decodedFramePool().contains(121), IsTrue());
+				AssertThat(engine->decodedFramePool().contains(122), IsTrue());
+				AssertThat(engine->decodedFramePool().contains(123), IsTrue());
+				AssertThat(engine->decodedFramePool().contains(124), IsTrue());
+				// pool has discarded the oldest frames
+				AssertThat(engine->decodedFramePool().contains(0), IsFalse());
+				AssertThat(engine->decodedFramePool().contains(1), IsFalse());
+				AssertThat(engine->decodedFramePool().contains(2), IsFalse());
+				AssertThat(engine->decodedFramePool().contains(3), IsFalse());
+				AssertThat(engine->decodedFramePool().contains(4), IsFalse());
+				AssertThat(engine->decodedFramePool().contains(5), IsFalse());
+				AssertThat(engine->decodedFramePool().contains(6), IsFalse());
+				AssertThat(engine->decodedFramePool().contains(7), IsFalse());
+				AssertThat(engine->decodedFramePool().contains(8), IsFalse());
+				AssertThat(engine->decodedFramePool().contains(9), IsFalse());
+				AssertThat(engine->decodedFramePool().contains(10), IsTrue());
 			});
 
 			it("handles offset", [&]() {


### PR DESCRIPTION
In the current design, there is a significant performance bottleneck in maintaining the _requestedFrames list each time the clock advances.

Here this bottleneck is removed by making the decoder class work differently. Instead of maintaining a list of requested frames, the decoder compares the current time, the readahead time, and the playback
direction to decide whether to continue decoding the next frame, to seek or stop.

Additionally, the seeking threshold is reduced to a minimum for MJPEG videos where every frames are keyframes.

This fixes #398.