### PR TITLE
Travis Build: Fix build for PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,11 +39,11 @@ matrix:
     - COVERITY_SCAN_NOTIFICATION_EMAIL=martin@phonations.com
     - COVERITY_SCAN_BRANCH_PATTERN=master
     - COVERITY_SCAN_BUILD_COMMAND=make
-    - COVERITY_SCAN_BUILD_COMMAND_PREPEND="cov-configure --comptype clangcxx --compiler
-      clang++"
+    - COVERITY_SCAN_BUILD_COMMAND_PREPEND="cov-configure --comptype clangcxx --compiler clang++"
+    # COVERITY_SCAN_TOKEN:
     - secure: YlyaETwveWXOT1wpOz68Vp8Pj1zZ5u44ppOabNw/Xe4M8ZHdPy3QkmyB7wTeUgNjlHzkW23aOOzTk8bm5wxS1iQRxHsQ/DnZd0TcULPuTY9+yO2L/Wkwk6quFBqGlkT8h2v4xkRDyshG8OxF6eqeeq5Cflt/LOhx+MnJqse9EzQ=
     os: linux
-    script: if [[ "$TRAVIS_BRANCH" == "$COVERITY_SCAN_BRANCH_PATTERN" ]]; then curl
+    script: if [[ "${TRAVIS_PULL_REQUEST}" == "false" ]] && [[ "$TRAVIS_BRANCH" == "$COVERITY_SCAN_BRANCH_PATTERN" ]]; then curl
       -s "$COVERITY_SCAN_SCRIPT" | bash; fi
   - env:
     - QTVER=551
@@ -75,7 +75,7 @@ install:
 - scripts/install_ffmpeg.sh
 - scripts/install_portaudio.sh
 - scripts/install_rtmidi.sh
-- if [[ "$TRAVIS_OS_NAME" == osx ]]; then scripts/add_key.sh; fi
+- if [[ "${TRAVIS_PULL_REQUEST}" == "false" ]]; then scripts/add_key.sh; fi
 before_script: qmake $PROJECT
 script: make
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ matrix:
     before_install: sudo pip install cpp-coveralls
     script:
     - make
-    - "./AllSpecs"
+    - travis_wait "./AllSpecs"
     after_success: coveralls -E .+/moc_.+ -E .+/ui_.+ -E .+\.app -E .+/tests/.+ -E
       .+/app/.+ -E .+/specs/.+
     after_failure: "./scripts/upload.sh *.result.bmp"

--- a/scripts/add_key.sh
+++ b/scripts/add_key.sh
@@ -2,10 +2,11 @@
 
 # Taken from https://www.objc.io/issues/6-build-tools/travis-ci/#add-scripts
 
+# Exit immediately if a command exits with a non-zero status.
 set -e
 
 # Decrypt certificates
-openssl aes-256-cbc -K $encrypted_5acf05a46408_key -iv $encrypted_5acf05a46408_iv -in scripts/certs/certs.tar.enc -out scripts/certs/certs.tar -d
+openssl aes-256-cbc -K "${encrypted_5acf05a46408_key}" -iv "${encrypted_5acf05a46408_iv}" -in scripts/certs/certs.tar.enc -out scripts/certs/certs.tar -d
 tar xvf scripts/certs/certs.tar
 
 # Create a custom keychain


### PR DESCRIPTION
Currently, Travis PR builds fail with the following error:

```
$ if [[ "$TRAVIS_OS_NAME" == osx ]]; then scripts/add_key.sh; fi
iv undefined
```

For example, see: https://travis-ci.org/Phonations/joker/jobs/207146498

There is also an error with the Coverity scan.

The root cause is that secured environment variables are not available in PR builds.

In the current PR, we fix the PR builds and make 2 additional changes to improve all builds:
- bypass the add_keys script and the Coverity scan when TRAVIS_PULL_REQUEST is false. Both of them cannot succeed in a Pull Request.
- Escape the environment variables in add_keys.sh. If an issue with secured variables appear in the future (such as an undefined variable, or a variable containing special characters), it will be easier to diagnose.
- Additionally, the timeout for the AllSpecs step is increased to 20 minutes, since it was observed to be failing randomly with the current value.
