### PR TITLE
InnoSetup: Use build number

### DIFF
--- a/common/common.iss
+++ b/common/common.iss
@@ -18,15 +18,11 @@
 #endif
 
 #define FileVerStr GetFileVersion(MyAppSrc)
-#define StripBuild(str VerStr) Copy(VerStr, 1, RPos(".", VerStr)-1)
-#define MyAppVerStr StripBuild(FileVerStr)
-#define MyAppVerName MyAppName + " v" + MyAppVerStr
-
 #define QtDir GetEnv('QTDIR')
 
 [Setup]
 AppName={#MyAppName}
-AppVersion={#MyAppVerStr}
+AppVersion={#FileVerStr}
 AppPublisher={#MyAppPublisher}
 AppPublisherURL={#MyAppURL}
 AppSupportURL={#MyAppURL}
@@ -36,7 +32,7 @@ DisableDirPage=yes
 DefaultGroupName={#MyAppName}
 DisableProgramGroupPage=yes
 OutputDir={#PWD}
-OutputBaseFilename={#MyAppName}_v{#MyAppVerStr}
+OutputBaseFilename={#MyAppName}_v{#FileVerStr}
 Compression=lzma
 SolidCompression=yes
 UninstallDisplayIcon={app}\{#MyAppExeName}

--- a/common/common.pri
+++ b/common/common.pri
@@ -25,6 +25,9 @@ isEmpty(ICON) {
 VERSION = $$system(git describe --abbrev=0 --tags)
 BUILD = $$system(git rev-list $${VERSION}.. --count)
 
+# append build number to version tag
+VERSION = $${VERSION}.$${BUILD}
+
 PH_GIT_BRANCH = $$system(git rev-parse --abbrev-ref HEAD)
 PH_GIT_REVISION = $$system(git rev-parse HEAD)
 if(equals(PH_GIT_BRANCH, "master") || equals(PH_GIT_BRANCH, "HEAD")) {


### PR DESCRIPTION
Currently the InnoSetup installer takes the version number from the Git tag (nice idea!), but does not take into account the build number (=number of commits since the tag). This has several drawbacks:
- Different installers built after the same tag have the same file name (for example `Joker_v2.1.4.exe`), so they cannot be distinguished.
- These installers have the same file version too (`2.1.4.0`), so that automated software management systems (like Microsoft SCCM) do not detect that they are different and refuse to install any update.

In the current PR, the project file and the Innosetup file are modified to include the build number in the installer file name and in the file version.

Thanks!