### PR TITLE
Do not run add_keys.sh on Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,7 @@ install:
 - scripts/install_ffmpeg.sh
 - scripts/install_portaudio.sh
 - scripts/install_rtmidi.sh
-- if [[ "${TRAVIS_PULL_REQUEST}" == "false" ]]; then scripts/add_key.sh; fi
+- if [[ "${TRAVIS_PULL_REQUEST}" == "false" ]] && [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then scripts/add_key.sh; fi
 before_script: qmake $PROJECT
 script: make
 notifications:


### PR DESCRIPTION
add_keys.sh is based on the 'security' command, which is only available on MacOS. Only run it there. This should fix the Travis issues for Linux builds on the master branch.