### PR TITLE
Fix tests

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/MartinDelille/rtmidi.git
 [submodule "vendor/bandit"]
 	path = vendor/bandit
-	url = https://github.com/joakimkarlsson/bandit
+	url = https://github.com/banditcpp/bandit
 [submodule "vendor/create-dmg"]
 	path = vendor/create-dmg
 	url = https://github.com/andreyvit/create-dmg.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ matrix:
     before_install: sudo pip install cpp-coveralls
     script:
     - make
-    - travis_wait "./AllSpecs"
+    - travis_wait "./AllSpecs --reporter=spec"
     after_success: coveralls -E .+/moc_.+ -E .+/ui_.+ -E .+\.app -E .+/tests/.+ -E
       .+/app/.+ -E .+/specs/.+
     after_failure: "./scripts/upload.sh *.result.bmp"

--- a/libs/PhVideo/PhVideoDecoder.cpp
+++ b/libs/PhVideo/PhVideoDecoder.cpp
@@ -174,7 +174,7 @@ void PhVideoDecoder::requestFrame(PhVideoBuffer *buffer)
 
 	_requestedFrames.append(buffer);
 
-	if (topLevel) {
+	if (topLevel && ready()) {
 		while (!_requestedFrames.empty()) {
 			QCoreApplication::processEvents();
 			decodeFrame();

--- a/specs/VideoSpec/VideoDecoderSpec.cpp
+++ b/specs/VideoSpec/VideoDecoderSpec.cpp
@@ -59,12 +59,12 @@ go_bandit([](){
 			PhVideoBuffer buffer0, buffer1, buffer2;
 			PhVideoBuffer *expectedBuffer = NULL;
 			PhFrame expectedFrame = 0;
-			int openedCallCount = 0;
+			int frameAvailableCallCount = 0;
 
 			QObject::connect(decoder, &PhVideoDecoder::frameAvailable, [&](PhVideoBuffer *buffer){
 				AssertThat(buffer, Equals(expectedBuffer));
 				AssertThat(buffer->frame(), Equals(expectedFrame));
-				openedCallCount += 1;
+				frameAvailableCallCount += 1;
 			});
 
 			expectedBuffer = &buffer0;
@@ -72,21 +72,21 @@ go_bandit([](){
 			decoder->requestFrame(&buffer0);
 			decoder->decodeFrame();
 
-			AssertThat(openedCallCount, Equals(1));
+			AssertThat(frameAvailableCallCount, Equals(1));
 
 			expectedBuffer = &buffer1;
 			buffer1.setRequestFrame(1);
 			expectedFrame = 1;
 			decoder->requestFrame(&buffer1);
 			decoder->decodeFrame();
-			AssertThat(openedCallCount, Equals(2));
+			AssertThat(frameAvailableCallCount, Equals(2));
 
 			expectedBuffer = &buffer2;
 			buffer2.setRequestFrame(2);
 			expectedFrame = 2;
 			decoder->requestFrame(&buffer2);
 			decoder->decodeFrame();
-			AssertThat(openedCallCount, Equals(3));
+			AssertThat(frameAvailableCallCount, Equals(3));
 		});
 	});
 });

--- a/specs/VideoSpec/VideoDecoderSpec.cpp
+++ b/specs/VideoSpec/VideoDecoderSpec.cpp
@@ -3,33 +3,19 @@
 #include "PhTools/PhDebug.h"
 #include "PhVideo/PhVideoDecoder.h"
 
-#include <QSignalSpy>
-
-#define OPEN_WAIT_TIME 10000
-
 using namespace bandit;
 
 go_bandit([](){
 	describe("decoder", [](){
 		PhVideoDecoder *decoder;
-		QSignalSpy *openedSpy, *openFailedSpy, *frameAvailableSpy;
 
 		before_each([&](){
-			qRegisterMetaType<PhTime>("PhTime");
-
 			decoder = new PhVideoDecoder();
-			openedSpy = new QSignalSpy(decoder, &PhVideoDecoder::opened);
-			openFailedSpy = new QSignalSpy(decoder, &PhVideoDecoder::openFailed);
-			frameAvailableSpy = new QSignalSpy(decoder, &PhVideoDecoder::frameAvailable);
-		});
-
-		after_each([&](){
-			delete openedSpy;
-			delete openFailedSpy;
-			delete decoder;
 		});
 
 		it("succeed", [&](){
+			int openedCallCount = 0;
+			int openFailedCallCount = 0;
 
 			QObject::connect(decoder, &PhVideoDecoder::opened, [&](PhTimeCodeType tcType, PhFrame frameIn, PhFrame length, int width, int height, QString codecName) {
 				AssertThat(tcType, Equals(PhTimeCodeType25));
@@ -42,18 +28,29 @@ go_bandit([](){
 #else
 				AssertThat(codecName, Equals("bmp"));
 #endif
+				openedCallCount += 1;
 			});
 
-			AssertThat(openedSpy->count(), Equals(0));
+			QObject::connect(decoder, &PhVideoDecoder::openFailed, [&]() {
+				openFailedCallCount += 1;
+			});
+
+			AssertThat(openedCallCount, Equals(0));
 			decoder->open("interlace_%03d.bmp");
-			AssertThat(openedSpy->count(), Equals(1));
-			AssertThat(openFailedSpy->count(), Equals(0));
+			AssertThat(openedCallCount, Equals(1));
+			AssertThat(openFailedCallCount, Equals(0));
 
 		});
 
 		it("fails", [&](){
+			int callCount = 0;
+
+			QObject::connect(decoder, &PhVideoDecoder::opened, [&](PhTimeCodeType tcType, PhFrame frameIn, PhFrame length, int width, int height, QString codecName) {
+				callCount += 1;
+			});
+
 			decoder->open("unexistingfile.mkv");
-			AssertThat(openedSpy->count(), Equals(0));
+			AssertThat(callCount, Equals(0));
 		});
 
 		it("decode frame", [&](){
@@ -62,10 +59,12 @@ go_bandit([](){
 			PhVideoBuffer buffer0, buffer1, buffer2;
 			PhVideoBuffer *expectedBuffer = NULL;
 			PhFrame expectedFrame = 0;
+			int callCount = 0;
 
 			QObject::connect(decoder, &PhVideoDecoder::frameAvailable, [&](PhVideoBuffer *buffer){
 				AssertThat(buffer, Equals(expectedBuffer));
 				AssertThat(buffer->frame(), Equals(expectedFrame));
+				callCount += 1;
 			});
 
 			expectedBuffer = &buffer0;
@@ -73,21 +72,21 @@ go_bandit([](){
 			decoder->requestFrame(&buffer0);
 			decoder->decodeFrame();
 
-			AssertThat(frameAvailableSpy->count(), Equals(1));
+			AssertThat(callCount, Equals(1));
 
 			expectedBuffer = &buffer1;
 			buffer1.setRequestFrame(1);
 			expectedFrame = 1;
 			decoder->requestFrame(&buffer1);
 			decoder->decodeFrame();
-			AssertThat(frameAvailableSpy->count(), Equals(2));
+			AssertThat(callCount, Equals(2));
 
 			expectedBuffer = &buffer2;
 			buffer2.setRequestFrame(2);
 			expectedFrame = 2;
 			decoder->requestFrame(&buffer2);
 			decoder->decodeFrame();
-			AssertThat(frameAvailableSpy->count(), Equals(3));
+			AssertThat(callCount, Equals(3));
 		});
 	});
 });

--- a/specs/VideoSpec/VideoDecoderSpec.cpp
+++ b/specs/VideoSpec/VideoDecoderSpec.cpp
@@ -59,12 +59,12 @@ go_bandit([](){
 			PhVideoBuffer buffer0, buffer1, buffer2;
 			PhVideoBuffer *expectedBuffer = NULL;
 			PhFrame expectedFrame = 0;
-			int callCount = 0;
+			int openedCallCount = 0;
 
 			QObject::connect(decoder, &PhVideoDecoder::frameAvailable, [&](PhVideoBuffer *buffer){
 				AssertThat(buffer, Equals(expectedBuffer));
 				AssertThat(buffer->frame(), Equals(expectedFrame));
-				callCount += 1;
+				openedCallCount += 1;
 			});
 
 			expectedBuffer = &buffer0;
@@ -72,21 +72,21 @@ go_bandit([](){
 			decoder->requestFrame(&buffer0);
 			decoder->decodeFrame();
 
-			AssertThat(callCount, Equals(1));
+			AssertThat(openedCallCount, Equals(1));
 
 			expectedBuffer = &buffer1;
 			buffer1.setRequestFrame(1);
 			expectedFrame = 1;
 			decoder->requestFrame(&buffer1);
 			decoder->decodeFrame();
-			AssertThat(callCount, Equals(2));
+			AssertThat(openedCallCount, Equals(2));
 
 			expectedBuffer = &buffer2;
 			buffer2.setRequestFrame(2);
 			expectedFrame = 2;
 			decoder->requestFrame(&buffer2);
 			decoder->decodeFrame();
-			AssertThat(callCount, Equals(3));
+			AssertThat(openedCallCount, Equals(3));
 		});
 	});
 });

--- a/specs/VideoSpec/VideoSpec.cpp
+++ b/specs/VideoSpec/VideoSpec.cpp
@@ -42,8 +42,13 @@ go_bandit([](){
 			openSpy = new QSignalSpy(engine, &PhVideoEngine::opened);
 			decodeSpy = new QSignalSpy(engine, &PhVideoEngine::newFrameDecoded);
 
-			// This is just for opengl initialization
-//			view->show();
+			// make sure the 64x64 window size will be preserved (required on Windows)
+			view->setWindowFlags(Qt::FramelessWindowHint);
+
+			// the widget needs to be shown for paint signals to be received (at least on Windows)
+			view->show();
+
+			// OpenGL initialization
 			view->renderPixmap(64, 64);
 
 			engine->setBilinearFiltering(false);

--- a/specs/VideoSpec/VideoSpec.cpp
+++ b/specs/VideoSpec/VideoSpec.cpp
@@ -82,7 +82,7 @@ go_bandit([](){
 
 			before_each([&](){
 				AssertThat(engine->open("interlace_%03d.bmp"), IsTrue());
-				AssertThat(openSpy->wait(OPEN_WAIT_TIME), IsTrue());
+				AssertThat(openSpy->count() == 1 || openSpy->wait(OPEN_WAIT_TIME), IsTrue());
 				QTest::qWait(FRAME_WAIT_TIME);
 			});
 
@@ -369,7 +369,7 @@ go_bandit([](){
 
 			before_each([&](){
 				AssertThat(engine->open("interlace_x264_25fps.mkv"), IsTrue());
-				AssertThat(openSpy->wait(OPEN_WAIT_TIME), IsTrue());
+				AssertThat(openSpy->count() == 1 || openSpy->wait(OPEN_WAIT_TIME), IsTrue());
 				QTest::qWait(FRAME_WAIT_TIME);
 			});
 


### PR DESCRIPTION
Dear Martin, to move forward with other PRs (like #414 and #416), it would be reassuring to start from a working test suite, but it seems the tests have been failing a lot on Travis lately...

This PR fixes a possible infinite loop when the engine is not ready, that may explain why the tests end with a timeout, and fixes another possible race condition where we would wait for a signal although it may have been emitted before we started waiting.

In VideoDecoderSpec, it also replaces QSignalSpy by a simpler connect() call on a lambda. This avoids Qt errors about types that are not registered.

Finally, it contains fixes for VideoSpec to make it run successfully on Windows (window size issues).

Thank you for considering this!