### PR TITLE
Fix log file location on Windows

### DIFF
--- a/libs/PhTools/PhDebug.cpp
+++ b/libs/PhTools/PhDebug.cpp
@@ -6,6 +6,7 @@
 
 #include <QDate>
 #include <QDir>
+#include <QStandardPaths>
 
 #include <iostream>
 
@@ -133,7 +134,7 @@ PhDebug::PhDebug() : _currentLogLevel(0), _textLog(NULL)
 #if defined(Q_OS_MAC)
 	                     .arg(QDir::homePath() + "/Library/Logs")
 #elif defined(Q_OS_WIN)
-	                     .arg(QString(qgetenv("APPDATA")))
+	                     .arg(QString::fromLocal8Bit(qgetenv("APPDATA")))
 #elif defined(Q_OS_LINUX)
 	                     .arg("/var/log")
 #endif

--- a/specs/ToolsSpec/DebugSpec.cpp
+++ b/specs/ToolsSpec/DebugSpec.cpp
@@ -66,11 +66,17 @@ go_bandit([](){
 		});
 
 		it("log_in_file", []() {
-			QString expected = QString("%1/Library/Logs/%2/%3.log")
-					.arg(QDir::homePath())
+			QString expected = QString("%1/%2/%3.log")
+#if defined(Q_OS_MAC)
+					.arg(QDir::homePath() + "/Library/Logs")
+#elif defined(Q_OS_WIN)
+					.arg(QString::fromLocal8Bit(qgetenv("APPDATA")))
+#elif defined(Q_OS_LINUX)
+					.arg("/var/log")
+#endif
 					.arg(PH_ORG_NAME)
 					.arg(PH_APP_NAME);
-			AssertThat(PhDebug::logLocation(), Equals(expected));
+			AssertThat(QDir::cleanPath(PhDebug::logLocation()), Equals(QDir::cleanPath(expected)));
 		});
 
 		it("display_in_the_debug", []() {


### PR DESCRIPTION
On Windows, when the user name contains special characters, the log file location ends up being garbled and the logs are not written anywhere. Fix this with fromLocal8Bit.

Also fix test to pass on Windows.