### PR TITLE
Settings: read/write performance improvements

### DIFF
--- a/app/Joker/JokerSettings.h
+++ b/app/Joker/JokerSettings.h
@@ -20,7 +20,6 @@
 #include "PhLtc/PhLtcReaderSettings.h"
 #endif
 
-
 /**
  * @brief The Joker application settings
  */
@@ -39,6 +38,8 @@ class JokerSettings : public PhGenericSettings,
 #endif
 	public PhSyncSettings
 {
+	Q_OBJECT
+
 public:
 	// PhWindowSettings
 	PH_SETTING_BOOL(setFullScreen, fullScreen)

--- a/app/Joker/JokerWindow.cpp
+++ b/app/Joker/JokerWindow.cpp
@@ -48,7 +48,8 @@ JokerWindow::JokerWindow(JokerSettings *settings) :
 	_firstDoc(true),
 	_resizingStrip(false),
 	_setCurrentTimeToVideoTimeIn(false),
-	_syncTimeInToDoc(false)
+	_syncTimeInToDoc(false),
+	_timePlayed(settings->timePlayed())
 {
 	// Setting up UI
 	ui->setupUi(this);
@@ -184,6 +185,8 @@ void JokerWindow::closeEvent(QCloseEvent *event)
 		// since closeEvent is called twice
 		// https://bugreports.qt.io/browse/QTBUG-43344
 		_doc->setModified(false);
+
+		_settings->setTimePlayed(_timePlayed);
 	}
 }
 
@@ -937,7 +940,7 @@ bool JokerWindow::openVideoFile(QString videoFile)
 void JokerWindow::timeCounter(PhTime elapsedTime)
 {
 	if(currentRate() == 1 && (PhSynchronizer::SyncType)_settings->synchroProtocol() != PhSynchronizer::NoSync) {
-		_settings->setTimePlayed(_settings->timePlayed() + elapsedTime);
+		_timePlayed += elapsedTime;
 	}
 }
 
@@ -981,7 +984,7 @@ void JokerWindow::on_actionAbout_triggered()
 	hideMediaPanel();
 
 	AboutDialog dlg;
-	dlg.setTimePlayed(_settings->timePlayed());
+	dlg.setTimePlayed(_timePlayed);
 	dlg.exec();
 
 	showMediaPanel();

--- a/app/Joker/JokerWindow.h
+++ b/app/Joker/JokerWindow.h
@@ -321,6 +321,8 @@ private:
 
 	bool _setCurrentTimeToVideoTimeIn;
 	bool _syncTimeInToDoc;
+
+	PhTime _timePlayed;
 };
 
 #endif // MAINWINDOW_H

--- a/app/LTCTool/LTCToolSettings.h
+++ b/app/LTCTool/LTCToolSettings.h
@@ -11,6 +11,8 @@
 class LTCToolSettings : protected PhGenericSettings,
 	public PhLtcReaderSettings
 {
+	Q_OBJECT
+
 public:
 	PH_SETTING_BOOL2(setGenerate, generate, true)
 	PH_SETTING_BOOL2(setRead, read, true)

--- a/app/MidiTool/MidiToolSettings.h
+++ b/app/MidiTool/MidiToolSettings.h
@@ -9,6 +9,8 @@
  */
 class MidiToolSettings : protected PhGenericSettings
 {
+	Q_OBJECT
+
 public:
 	PH_SETTING_BOOL2(setWriteMTC, writeMTC, true)
 	PH_SETTING_BOOL2(setReadMTC, readMTC, true)

--- a/app/SonyTool/SonyToolSettings.h
+++ b/app/SonyTool/SonyToolSettings.h
@@ -10,6 +10,8 @@
  */
 class SonyToolSettings : public PhGenericSettings, public PhSonySettings
 {
+	Q_OBJECT
+
 public:
 	// PhSonySettings:
 	PH_SETTING_BOOL2(setVideoSyncUp, videoSyncUp, true)

--- a/libs/PhGraphic/PhFont.cpp
+++ b/libs/PhGraphic/PhFont.cpp
@@ -44,9 +44,10 @@ int PhFont::computeMaxFontSize(QString family)
 	int size = 25;
 	int expectedFontHeight = 128;
 	int low = 0, high = 1000;
+	QFont font(family);
 	while (low < high) {
 		size = (low + high) / 2;
-		QFont font(family, size);
+		font.setPixelSize(size);
 		QFontMetrics fm(font);
 
 //		PHDEBUG << fm.height() << fm.ascent() << fm.descent() << fm.leading();

--- a/libs/PhTools/PhGenericSettings.h
+++ b/libs/PhTools/PhGenericSettings.h
@@ -10,147 +10,147 @@
 
 /** Implement the integer setter and getter for a PhGenericSettings */
 #define PH_SETTING_INT(setter, getter) \
-Q_PROPERTY(int getter READ getter WRITE setter NOTIFY getter##Changed) \
+	Q_PROPERTY(int getter READ getter WRITE setter NOTIFY getter ## Changed) \
 Q_SIGNALS: \
-	void getter##Changed(); \
+	void getter ## Changed(); \
 public slots: \
-	void setter(int value) { if (setIntValue(#getter, value)) { emit getter##Changed(); } } \
+	void setter(int value) { if (setIntValue(#getter, value)) { emit getter ## Changed(); } } \
 public: \
 	int getter() {return intValue(#getter); }
 
 /** Implement the integer setter, getter and default value for a PhGenericSettings */
 #define PH_SETTING_INT2(setter, getter, defaultValue) \
-Q_PROPERTY(int getter READ getter WRITE setter NOTIFY getter##Changed) \
+	Q_PROPERTY(int getter READ getter WRITE setter NOTIFY getter ## Changed) \
 Q_SIGNALS: \
-	void getter##Changed(); \
+	void getter ## Changed(); \
 public slots: \
-	void setter(int value) { if (setIntValue(#getter, value)) { emit getter##Changed(); } } \
-	void re ## setter() { if (setIntValue(#getter, defaultValue)) { emit getter##Changed(); } } \
+	void setter(int value) { if (setIntValue(#getter, value)) { emit getter ## Changed(); } } \
+	void re ## setter() { if (setIntValue(#getter, defaultValue)) { emit getter ## Changed(); } } \
 public: \
 	int getter() {return intValue(#getter, defaultValue); }
 
 /** Implement the integer setter, getter and alias for a PhGenericSettings */
 #define PH_SETTING_INT3(setter, getter, alias) \
-Q_PROPERTY(int getter READ getter WRITE setter NOTIFY getter##Changed) \
+	Q_PROPERTY(int getter READ getter WRITE setter NOTIFY getter ## Changed) \
 Q_SIGNALS: \
-	void getter##Changed(); \
+	void getter ## Changed(); \
 public slots: \
-	void setter(int value) { if (setIntValue(#getter, value)) { emit getter##Changed(); } } \
+	void setter(int value) { if (setIntValue(#getter, value)) { emit getter ## Changed(); } } \
 public: \
 	int getter() {return intValueWithAlias(#getter, #alias); }
 
 /** Implement the unsigned char setter and getter for a PhGenericSettings */
 #define PH_SETTING_UCHAR(setter, getter) \
-Q_PROPERTY(unsigned char getter READ getter WRITE setter NOTIFY getter##Changed) \
+	Q_PROPERTY(unsigned char getter READ getter WRITE setter NOTIFY getter ## Changed) \
 Q_SIGNALS: \
-	void getter##Changed(); \
+	void getter ## Changed(); \
 public slots: \
-	void setter(unsigned char value) { if (setIntValue(#getter, value)) { emit getter##Changed(); } } \
+	void setter(unsigned char value) { if (setIntValue(#getter, value)) { emit getter ## Changed(); } } \
 public: \
 	unsigned char getter() {return intValue(#getter); }
 
 /** Implement the unsigned char setter, getter and default value for a PhGenericSettings */
 #define PH_SETTING_UCHAR2(setter, getter, defaultValue) \
-Q_PROPERTY(unsigned char getter READ getter WRITE setter NOTIFY getter##Changed) \
+	Q_PROPERTY(unsigned char getter READ getter WRITE setter NOTIFY getter ## Changed) \
 Q_SIGNALS: \
-	void getter##Changed(); \
+	void getter ## Changed(); \
 public slots: \
-	void setter(unsigned char value) { if (setIntValue(#getter, value)) { emit getter##Changed(); } } \
-	void re ## setter() { if (setIntValue(#getter, defaultValue)) { emit getter##Changed(); } } \
+	void setter(unsigned char value) { if (setIntValue(#getter, value)) { emit getter ## Changed(); } } \
+	void re ## setter() { if (setIntValue(#getter, defaultValue)) { emit getter ## Changed(); } } \
 public: \
 	unsigned char getter() {return intValue(#getter, defaultValue); }
 
 /** Implement the bool setter and getter for a PhGenericSettings */
 #define PH_SETTING_BOOL(setter, getter) \
-Q_PROPERTY(bool getter READ getter WRITE setter NOTIFY getter##Changed) \
+	Q_PROPERTY(bool getter READ getter WRITE setter NOTIFY getter ## Changed) \
 Q_SIGNALS: \
-	void getter##Changed(); \
+	void getter ## Changed(); \
 public slots: \
-	void setter(bool value) { if (setBoolValue(#getter, value)) { emit getter##Changed(); } } \
+	void setter(bool value) { if (setBoolValue(#getter, value)) { emit getter ## Changed(); } } \
 public: \
 	bool getter() {return boolValue(#getter); }
 
 /** Implement the bool setter, getter and default value for a PhGenericSettings */
 #define PH_SETTING_BOOL2(setter, getter, defaultValue) \
-Q_PROPERTY(bool getter READ getter WRITE setter NOTIFY getter##Changed) \
+	Q_PROPERTY(bool getter READ getter WRITE setter NOTIFY getter ## Changed) \
 Q_SIGNALS: \
-   void getter##Changed(); \
+	void getter ## Changed(); \
 public slots: \
-	void setter(bool value) { if (setBoolValue(#getter, value)) { emit getter##Changed(); } } \
-	void re ## setter() { if (setBoolValue(#getter, defaultValue)) { emit getter##Changed(); } } \
+	void setter(bool value) { if (setBoolValue(#getter, value)) { emit getter ## Changed(); } } \
+	void re ## setter() { if (setBoolValue(#getter, defaultValue)) { emit getter ## Changed(); } } \
 public: \
 	bool getter() {return boolValue(#getter, defaultValue); } \
 
 /** Implement the float setter and getter for a PhGenericSettings */
 #define PH_SETTING_FLOAT(setter, getter) \
-Q_PROPERTY(float getter READ getter WRITE setter NOTIFY getter##Changed) \
+	Q_PROPERTY(float getter READ getter WRITE setter NOTIFY getter ## Changed) \
 Q_SIGNALS: \
-	void getter##Changed(); \
+	void getter ## Changed(); \
 public slots: \
-	void setter(float value) { if (setFloatValue(#getter, value)) { emit getter##Changed(); } } \
+	void setter(float value) { if (setFloatValue(#getter, value)) { emit getter ## Changed(); } } \
 public: \
 	float getter() {return floatValue(#getter); }
 
 /** Implement the float setter, getter and default value for a PhGenericSettings */
 #define PH_SETTING_FLOAT2(setter, getter, defaultValue) \
-Q_PROPERTY(float getter READ getter WRITE setter NOTIFY getter##Changed) \
+	Q_PROPERTY(float getter READ getter WRITE setter NOTIFY getter ## Changed) \
 Q_SIGNALS: \
-	void getter##Changed(); \
+	void getter ## Changed(); \
 public slots: \
-	void setter(float value) { if (setFloatValue(#getter, value)) { emit getter##Changed(); } } \
-	void re ## setter() { if (setFloatValue(#getter, defaultValue)) { emit getter##Changed(); } } \
+	void setter(float value) { if (setFloatValue(#getter, value)) { emit getter ## Changed(); } } \
+	void re ## setter() { if (setFloatValue(#getter, defaultValue)) { emit getter ## Changed(); } } \
 public: \
 	float getter() {return floatValue(#getter, defaultValue); }
 
 /** Implement the string setter and getter for a PhGenericSettings */
 #define PH_SETTING_STRING(setter, getter) \
-Q_PROPERTY(QString getter READ getter WRITE setter NOTIFY getter##Changed) \
+	Q_PROPERTY(QString getter READ getter WRITE setter NOTIFY getter ## Changed) \
 Q_SIGNALS: \
-	void getter##Changed(); \
+	void getter ## Changed(); \
 public slots: \
-	void setter(QString value) { if (setStringValue(#getter, value)) { emit getter##Changed(); } } \
+	void setter(QString value) { if (setStringValue(#getter, value)) { emit getter ## Changed(); } } \
 public: \
 	QString getter() {return stringValue(#getter); }
 
 /** Implement the string setter, getter and default value for a PhGenericSettings */
 #define PH_SETTING_STRING2(setter, getter, defaultValue) \
-Q_PROPERTY(QString getter READ getter WRITE setter NOTIFY getter##Changed) \
+	Q_PROPERTY(QString getter READ getter WRITE setter NOTIFY getter ## Changed) \
 Q_SIGNALS: \
-	void getter##Changed(); \
+	void getter ## Changed(); \
 public slots: \
-	void setter(QString value) { if (setStringValue(#getter, value)) { emit getter##Changed(); } } \
-	void re ## setter() { if (setStringValue(#getter, defaultValue)) { emit getter##Changed(); } } \
+	void setter(QString value) { if (setStringValue(#getter, value)) { emit getter ## Changed(); } } \
+	void re ## setter() { if (setStringValue(#getter, defaultValue)) { emit getter ## Changed(); } } \
 public: \
 	QString getter() {return stringValue(#getter, defaultValue); }
 
 /** Implement the string list setter and getter for a PhGenericSettings */
 #define PH_SETTING_STRINGLIST(setter, getter) \
-Q_PROPERTY(QStringList getter READ getter WRITE setter NOTIFY getter##Changed) \
+	Q_PROPERTY(QStringList getter READ getter WRITE setter NOTIFY getter ## Changed) \
 Q_SIGNALS: \
-	void getter##Changed(); \
+	void getter ## Changed(); \
 public slots: \
-	void setter(QStringList list) { if (setStringList(#getter, list)) { emit getter##Changed(); } } \
+	void setter(QStringList list) { if (setStringList(#getter, list)) { emit getter ## Changed(); } } \
 public: \
 	QStringList getter() {return stringList(#getter); }
 
 /** Implement the string list setter and getter qnd default value for a PhGenericSettings */
 #define PH_SETTING_STRINGLIST2(setter, getter, defaultValue) \
-Q_PROPERTY(QStringList getter READ getter WRITE setter NOTIFY getter##Changed) \
+	Q_PROPERTY(QStringList getter READ getter WRITE setter NOTIFY getter ## Changed) \
 Q_SIGNALS: \
-	void getter##Changed(); \
+	void getter ## Changed(); \
 public slots: \
-	void setter(QStringList list) { if (setStringList(#getter, list)) { emit getter##Changed(); } } \
-	void re ## setter() { if (setStringList(#getter, defaultValue)) { emit getter##Changed(); } } \
+	void setter(QStringList list) { if (setStringList(#getter, list)) { emit getter ## Changed(); } } \
+	void re ## setter() { if (setStringList(#getter, defaultValue)) { emit getter ## Changed(); } } \
 public: \
 	QStringList getter() {return stringList(#getter, defaultValue); }
 
 /** Implement the byte array setter and getter for a PhGenericSettings */
 #define PH_SETTING_BYTEARRAY(setter, getter) \
-Q_PROPERTY(QByteArray getter READ getter WRITE setter NOTIFY getter##Changed) \
+	Q_PROPERTY(QByteArray getter READ getter WRITE setter NOTIFY getter ## Changed) \
 Q_SIGNALS: \
-	void getter##Changed(); \
+	void getter ## Changed(); \
 public slots: \
-	void setter(QByteArray array) { if (setByteArray(#getter, array)) { emit getter##Changed(); } } \
+	void setter(QByteArray array) { if (setByteArray(#getter, array)) { emit getter ## Changed(); } } \
 public: \
 	QByteArray getter() {return byteArray(#getter); }
 
@@ -158,9 +158,9 @@ public: \
 //	Q_PROPERTY does not work here, there is no single-argument setter
 #define PH_SETTING_HASH(setter, getter) \
 Q_SIGNALS: \
-	void getter##Changed(); \
+	void getter ## Changed(); \
 public slots: \
-	void setter(QString key, QVariant value) { if (setHash(#getter, key, value)) { emit getter##Changed(); } } \
+	void setter(QString key, QVariant value) { if (setHash(#getter, key, value)) { emit getter ## Changed(); } } \
 public: \
 	QVariant getter(QString key) {return hash(#getter, key); }
 
@@ -367,7 +367,7 @@ protected:
 	/**
 	 * @brief The cache for hash settings.
 	 */
-	QMap<QString, QHash<QString, QVariant>> _hashValues;
+	QMap<QString, QHash<QString, QVariant> > _hashValues;
 };
 
 #endif // PHGENERICSETTINGS_H

--- a/libs/PhTools/PhGenericSettings.h
+++ b/libs/PhTools/PhGenericSettings.h
@@ -329,14 +329,44 @@ protected:
 	 */
 	QSettings _settings;
 
-	// caches
+	/**
+	 * @brief The cache for int settings.
+	 */
 	QMap<QString, int> _intValues;
+
+	/**
+	 * @brief The cache for long long settings.
+	 */
 	QMap<QString, qlonglong> _longLongValues;
+
+	/**
+	 * @brief The cache for float settings.
+	 */
 	QMap<QString, float> _floatValues;
+
+	/**
+	 * @brief The cache for bool settings.
+	 */
 	QMap<QString, bool> _boolValues;
+
+	/**
+	 * @brief The cache for string settings.
+	 */
 	QMap<QString, QString> _stringValues;
+
+	/**
+	 * @brief The cache for byte array settings.
+	 */
 	QMap<QString, QByteArray> _byteArrayValues;
+
+	/**
+	 * @brief The cache for string list settings.
+	 */
 	QMap<QString, QStringList> _stringListValues;
+
+	/**
+	 * @brief The cache for hash settings.
+	 */
 	QMap<QString, QHash<QString, QVariant>> _hashValues;
 };
 

--- a/libs/PhTools/PhGenericSettings.h
+++ b/libs/PhTools/PhGenericSettings.h
@@ -10,112 +10,157 @@
 
 /** Implement the integer setter and getter for a PhGenericSettings */
 #define PH_SETTING_INT(setter, getter) \
+Q_PROPERTY(int getter READ getter WRITE setter NOTIFY getter##Changed) \
+Q_SIGNALS: \
+	void getter##Changed(); \
 public slots: \
-	void setter(int value) { setIntValue(#getter, value); } \
+	void setter(int value) { if (setIntValue(#getter, value)) { emit getter##Changed(); } } \
 public: \
 	int getter() {return intValue(#getter); }
 
 /** Implement the integer setter, getter and default value for a PhGenericSettings */
 #define PH_SETTING_INT2(setter, getter, defaultValue) \
+Q_PROPERTY(int getter READ getter WRITE setter NOTIFY getter##Changed) \
+Q_SIGNALS: \
+	void getter##Changed(); \
 public slots: \
-	void setter(int value) { setIntValue(#getter, value); } \
-	void re ## setter() { setIntValue(#getter, defaultValue); } \
+	void setter(int value) { if (setIntValue(#getter, value)) { emit getter##Changed(); } } \
+	void re ## setter() { if (setIntValue(#getter, defaultValue)) { emit getter##Changed(); } } \
 public: \
 	int getter() {return intValue(#getter, defaultValue); }
 
 /** Implement the integer setter, getter and alias for a PhGenericSettings */
 #define PH_SETTING_INT3(setter, getter, alias) \
+Q_PROPERTY(int getter READ getter WRITE setter NOTIFY getter##Changed) \
+Q_SIGNALS: \
+	void getter##Changed(); \
 public slots: \
-	void setter(int value) { setIntValue(#getter, value); } \
+	void setter(int value) { if (setIntValue(#getter, value)) { emit getter##Changed(); } } \
 public: \
 	int getter() {return intValueWithAlias(#getter, #alias); }
 
 /** Implement the unsigned char setter and getter for a PhGenericSettings */
 #define PH_SETTING_UCHAR(setter, getter) \
+Q_PROPERTY(unsigned char getter READ getter WRITE setter NOTIFY getter##Changed) \
+Q_SIGNALS: \
+	void getter##Changed(); \
 public slots: \
-	void setter(unsigned char value) { setIntValue(#getter, value); } \
+	void setter(unsigned char value) { if (setIntValue(#getter, value)) { emit getter##Changed(); } } \
 public: \
 	unsigned char getter() {return intValue(#getter); }
 
 /** Implement the unsigned char setter, getter and default value for a PhGenericSettings */
 #define PH_SETTING_UCHAR2(setter, getter, defaultValue) \
+Q_PROPERTY(unsigned char getter READ getter WRITE setter NOTIFY getter##Changed) \
+Q_SIGNALS: \
+	void getter##Changed(); \
 public slots: \
-	void setter(unsigned char value) { setIntValue(#getter, value); } \
-	void re ## setter() { setIntValue(#getter, defaultValue); } \
+	void setter(unsigned char value) { if (setIntValue(#getter, value)) { emit getter##Changed(); } } \
+	void re ## setter() { if (setIntValue(#getter, defaultValue)) { emit getter##Changed(); } } \
 public: \
 	unsigned char getter() {return intValue(#getter, defaultValue); }
 
 /** Implement the bool setter and getter for a PhGenericSettings */
 #define PH_SETTING_BOOL(setter, getter) \
+Q_PROPERTY(bool getter READ getter WRITE setter NOTIFY getter##Changed) \
+Q_SIGNALS: \
+	void getter##Changed(); \
 public slots: \
-	void setter(bool value) { setBoolValue(#getter, value); } \
+	void setter(bool value) { if (setBoolValue(#getter, value)) { emit getter##Changed(); } } \
 public: \
 	bool getter() {return boolValue(#getter); }
 
 /** Implement the bool setter, getter and default value for a PhGenericSettings */
 #define PH_SETTING_BOOL2(setter, getter, defaultValue) \
+Q_PROPERTY(bool getter READ getter WRITE setter NOTIFY getter##Changed) \
+Q_SIGNALS: \
+   void getter##Changed(); \
 public slots: \
-	void setter(bool value) { setBoolValue(#getter, value); } \
-	void re ## setter() { setBoolValue(#getter, defaultValue); } \
+	void setter(bool value) { if (setBoolValue(#getter, value)) { emit getter##Changed(); } } \
+	void re ## setter() { if (setBoolValue(#getter, defaultValue)) { emit getter##Changed(); } } \
 public: \
-	bool getter() {return boolValue(#getter, defaultValue); }
+	bool getter() {return boolValue(#getter, defaultValue); } \
 
 /** Implement the float setter and getter for a PhGenericSettings */
 #define PH_SETTING_FLOAT(setter, getter) \
+Q_PROPERTY(float getter READ getter WRITE setter NOTIFY getter##Changed) \
+Q_SIGNALS: \
+	void getter##Changed(); \
 public slots: \
-	void setter(float value) { setFloatValue(#getter, value); } \
+	void setter(float value) { if (setFloatValue(#getter, value)) { emit getter##Changed(); } } \
 public: \
 	float getter() {return floatValue(#getter); }
 
 /** Implement the float setter, getter and default value for a PhGenericSettings */
 #define PH_SETTING_FLOAT2(setter, getter, defaultValue) \
+Q_PROPERTY(float getter READ getter WRITE setter NOTIFY getter##Changed) \
+Q_SIGNALS: \
+	void getter##Changed(); \
 public slots: \
-	void setter(float value) { setFloatValue(#getter, value); } \
-	void re ## setter() { setFloatValue(#getter, defaultValue); } \
+	void setter(float value) { if (setFloatValue(#getter, value)) { emit getter##Changed(); } } \
+	void re ## setter() { if (setFloatValue(#getter, defaultValue)) { emit getter##Changed(); } } \
 public: \
 	float getter() {return floatValue(#getter, defaultValue); }
 
 /** Implement the string setter and getter for a PhGenericSettings */
 #define PH_SETTING_STRING(setter, getter) \
+Q_PROPERTY(QString getter READ getter WRITE setter NOTIFY getter##Changed) \
+Q_SIGNALS: \
+	void getter##Changed(); \
 public slots: \
-	void setter(QString value) { setStringValue(#getter, value); } \
+	void setter(QString value) { if (setStringValue(#getter, value)) { emit getter##Changed(); } } \
 public: \
 	QString getter() {return stringValue(#getter); }
 
 /** Implement the string setter, getter and default value for a PhGenericSettings */
 #define PH_SETTING_STRING2(setter, getter, defaultValue) \
+Q_PROPERTY(QString getter READ getter WRITE setter NOTIFY getter##Changed) \
+Q_SIGNALS: \
+	void getter##Changed(); \
 public slots: \
-	void setter(QString value) { setStringValue(#getter, value); } \
-	void re ## setter() { setStringValue(#getter, defaultValue); } \
+	void setter(QString value) { if (setStringValue(#getter, value)) { emit getter##Changed(); } } \
+	void re ## setter() { if (setStringValue(#getter, defaultValue)) { emit getter##Changed(); } } \
 public: \
 	QString getter() {return stringValue(#getter, defaultValue); }
 
 /** Implement the string list setter and getter for a PhGenericSettings */
 #define PH_SETTING_STRINGLIST(setter, getter) \
+Q_PROPERTY(QStringList getter READ getter WRITE setter NOTIFY getter##Changed) \
+Q_SIGNALS: \
+	void getter##Changed(); \
 public slots: \
-	void setter(QStringList list) { setStringList(#getter, list); } \
+	void setter(QStringList list) { if (setStringList(#getter, list)) { emit getter##Changed(); } } \
 public: \
 	QStringList getter() {return stringList(#getter); }
 
 /** Implement the string list setter and getter qnd default value for a PhGenericSettings */
 #define PH_SETTING_STRINGLIST2(setter, getter, defaultValue) \
+Q_PROPERTY(QStringList getter READ getter WRITE setter NOTIFY getter##Changed) \
+Q_SIGNALS: \
+	void getter##Changed(); \
 public slots: \
-	void setter(QStringList list) { setStringList(#getter, list); } \
-	void re ## setter() { setStringList(#getter, defaultValue); } \
+	void setter(QStringList list) { if (setStringList(#getter, list)) { emit getter##Changed(); } } \
+	void re ## setter() { if (setStringList(#getter, defaultValue)) { emit getter##Changed(); } } \
 public: \
 	QStringList getter() {return stringList(#getter, defaultValue); }
 
 /** Implement the byte array setter and getter for a PhGenericSettings */
 #define PH_SETTING_BYTEARRAY(setter, getter) \
+Q_PROPERTY(QByteArray getter READ getter WRITE setter NOTIFY getter##Changed) \
+Q_SIGNALS: \
+	void getter##Changed(); \
 public slots: \
-	void setter(QByteArray array) { setByteArray(#getter, array); } \
+	void setter(QByteArray array) { if (setByteArray(#getter, array)) { emit getter##Changed(); } } \
 public: \
 	QByteArray getter() {return byteArray(#getter); }
 
 /** Implement the hash setter and getter for a PhGenericSettings */
+//	Q_PROPERTY does not work here, there is no single-argument setter
 #define PH_SETTING_HASH(setter, getter) \
+Q_SIGNALS: \
+	void getter##Changed(); \
 public slots: \
-	void setter(QString key, QVariant value) { setHash(#getter, key, value); } \
+	void setter(QString key, QVariant value) { if (setHash(#getter, key, value)) { emit getter##Changed(); } } \
 public: \
 	QVariant getter(QString key) {return hash(#getter, key); }
 
@@ -149,8 +194,9 @@ protected:
 	 * @brief Set an integer value
 	 * @param name The settings name
 	 * @param value The integer value
+	 * @return Whether the value has changed
 	 */
-	void setIntValue(QString name, int value);
+	bool setIntValue(QString name, int value);
 	/**
 	 * @brief Get an integer value
 	 * @param name The settings name
@@ -162,8 +208,9 @@ protected:
 	 * @brief Set a long long value (64 bit)
 	 * @param name The settings name
 	 * @param value The long long value
+	 * @return Whether the value has changed
 	 */
-	void setLongLongValue(QString name, qlonglong value);
+	bool setLongLongValue(QString name, qlonglong value);
 	/**
 	 * @brief Get a long long value (64 bit)
 	 * @param name The settings name
@@ -184,8 +231,9 @@ protected:
 	 * @brief Set a bool value
 	 * @param name The settings name
 	 * @param value The bool value
+	 * @return Whether the value has changed
 	 */
-	void setBoolValue(QString name, bool value);
+	bool setBoolValue(QString name, bool value);
 	/**
 	 * @brief Get a bool value
 	 * @param name The settings name
@@ -198,8 +246,9 @@ protected:
 	 * @brief Set a float value
 	 * @param name The settings name
 	 * @param value The float value
+	 * @return Whether the value has changed
 	 */
-	void setFloatValue(QString name, float value);
+	bool setFloatValue(QString name, float value);
 	/**
 	 * @brief Get a float value
 	 * @param name The settings name
@@ -211,8 +260,9 @@ protected:
 	 * @brief Set a string value
 	 * @param name The settings name
 	 * @param value The string value
+	 * @return Whether the value has changed
 	 */
-	void setStringValue(QString name, QString value);
+	bool setStringValue(QString name, QString value);
 	/**
 	 * @brief Get a string value
 	 * @param name The settings name
@@ -224,8 +274,9 @@ protected:
 	 * @brief Set a string list
 	 * @param name The settings name
 	 * @param list The string list
+	 * @return Whether the value has changed
 	 */
-	void setStringList(QString name, QStringList list);
+	bool setStringList(QString name, QStringList list);
 	/**
 	 * @brief Get a string list
 	 * @param name The settings name
@@ -238,8 +289,9 @@ protected:
 	 * @brief Set a byte array
 	 * @param name The settings name
 	 * @param array The byte array
+	 * @return Whether the value has changed
 	 */
-	void setByteArray(QString name, QByteArray array);
+	bool setByteArray(QString name, QByteArray array);
 	/**
 	 * @brief Get a byte array
 	 * @param name The settings name
@@ -252,8 +304,9 @@ protected:
 	 * @param name Name of the hash
 	 * @param key Key
 	 * @param value Value
+	 * @return Whether the value has changed
 	 */
-	void setHash(QString name, QString key, QVariant value);
+	bool setHash(QString name, QString key, QVariant value);
 
 	/**
 	 * @brief Get a hash value for a key
@@ -262,11 +315,29 @@ protected:
 	 * @return A value
 	 */
 	QVariant hash(QString name, QString key);
+
+	/**
+	 * @brief Get a full hash (containing multiple values)
+	 * @param name The settings name
+	 * @return The hash
+	 */
+	QHash<QString, QVariant> fullHash(QString name);
+
 protected:
 	/**
 	 * @brief The QSettings object
 	 */
 	QSettings _settings;
+
+	// caches
+	QMap<QString, int> _intValues;
+	QMap<QString, qlonglong> _longLongValues;
+	QMap<QString, float> _floatValues;
+	QMap<QString, bool> _boolValues;
+	QMap<QString, QString> _stringValues;
+	QMap<QString, QByteArray> _byteArrayValues;
+	QMap<QString, QStringList> _stringListValues;
+	QMap<QString, QHash<QString, QVariant>> _hashValues;
 };
 
 #endif // PHGENERICSETTINGS_H

--- a/libs/PhTools/PhTools.pri
+++ b/libs/PhTools/PhTools.pri
@@ -10,11 +10,11 @@ HEADERS += \
 	$$PWD/PhTickCounter.h \
 	$$PWD/PhPictureTools.h \
 	$$PWD/PhFileTool.h \
-    $$PWD/PhGenericSettings.h
+	$$PWD/PhGenericSettings.h
 
 SOURCES += \
 	$$PWD/PhDebug.cpp \
 	$$PWD/PhTickCounter.cpp \
 	$$PWD/PhPictureTools.cpp \
 	$$PWD/PhFileTool.cpp \
-    $$PWD/PhGenericSettings.cpp
+	$$PWD/PhGenericSettings.cpp

--- a/specs/CommonUISpec/DocumentWindowSpecSettings.h
+++ b/specs/CommonUISpec/DocumentWindowSpecSettings.h
@@ -14,6 +14,8 @@
 
 class DocumentWindowSpecSettings : public PhGenericSettings, public PhDocumentWindowSettings
 {
+	Q_OBJECT
+
 public:
 	DocumentWindowSpecSettings() : PhGenericSettings(true) {
 	}

--- a/specs/CommonUISpec/WindowSpecSettings.h
+++ b/specs/CommonUISpec/WindowSpecSettings.h
@@ -8,6 +8,8 @@
 
 class WindowSpecSettings : public PhGenericSettings, public PhWindowSettings
 {
+	Q_OBJECT
+
 public:
 	WindowSpecSettings() : PhGenericSettings(true) {
 	}

--- a/specs/GraphicSpec/GraphicTextSpec.cpp
+++ b/specs/GraphicSpec/GraphicTextSpec.cpp
@@ -3,6 +3,7 @@
  * License: http://www.gnu.org/licenses/gpl.html GPL version 2 or higher
  */
 
+#include <QCoreApplication>
 #include <QFontDatabase>
 
 #include "PhTools/PhDebug.h"
@@ -81,7 +82,7 @@ go_bandit([](){
 		});
 
 		it("draw_bookerly_font", [&](){
-			int fontId = QFontDatabase::addApplicationFont("Bookerly-BoldItalic.ttf");
+			int fontId = QFontDatabase::addApplicationFont(QCoreApplication::applicationDirPath() + PATH_TO_RESSOURCES + "/Bookerly-BoldItalic.ttf");
 			AssertThat(fontId, IsGreaterThanOrEqualTo(0));
 
 			font->setFamily("Bookerly");
@@ -93,7 +94,7 @@ go_bandit([](){
 		});
 
 		it("draw_swenson_font", [&](){
-			int fontId = QFontDatabase::addApplicationFont("SWENSON.TTF");
+			int fontId = QFontDatabase::addApplicationFont(QCoreApplication::applicationDirPath() + PATH_TO_RESSOURCES + "/SWENSON.TTF");
 			AssertThat(fontId, IsGreaterThanOrEqualTo(0));
 
 			font->setFamily("Swenson");

--- a/specs/GraphicSpec/GraphicTextSpec.cpp
+++ b/specs/GraphicSpec/GraphicTextSpec.cpp
@@ -81,7 +81,9 @@ go_bandit([](){
 		});
 
 		it("draw_bookerly_font", [&](){
-			QFontDatabase::addApplicationFont("Bookerly-BoldItalic.ttf");
+			int fontId = QFontDatabase::addApplicationFont("Bookerly-BoldItalic.ttf");
+			AssertThat(fontId, IsGreaterThanOrEqualTo(0));
+
 			font->setFamily("Bookerly");
 			AssertThat(font->ready(), IsFalse());
 
@@ -91,8 +93,11 @@ go_bandit([](){
 		});
 
 		it("draw_swenson_font", [&](){
-			QFontDatabase::addApplicationFont("SWENSON.TTF");
+			int fontId = QFontDatabase::addApplicationFont("SWENSON.TTF");
+			AssertThat(fontId, IsGreaterThanOrEqualTo(0));
+
 			font->setFamily("Swenson");
+
 			AssertThat(font->ready(), IsFalse());
 
 			AssertThat(view->compare("fontTest.SWENSON.ttf.bmp", threshold), IsLessThan(threshold));

--- a/specs/SyncSpec/SyncSpecSettings.h
+++ b/specs/SyncSpec/SyncSpecSettings.h
@@ -14,6 +14,8 @@
 class SyncSpecSettings : protected PhGenericSettings,
 		public PhSyncSettings
 {
+	Q_OBJECT
+
 public:
 	SyncSpecSettings() : PhGenericSettings(true) {
 	}

--- a/specs/ToolsSpec/SettingsSpecSettings.h
+++ b/specs/ToolsSpec/SettingsSpecSettings.h
@@ -9,6 +9,8 @@
  */
 class SettingsSpecSettings : public PhGenericSettings
 {
+	Q_OBJECT
+
 public:
 	PH_SETTING_INT(setIntTest1, intTest1)
 	PH_SETTING_INT(setIntTest2, intTest2)

--- a/specs/VideoSpec/VideoSpecSettings.h
+++ b/specs/VideoSpec/VideoSpecSettings.h
@@ -13,6 +13,8 @@
 class VideoSpecSettings : protected PhGenericSettings,
 		public PhVideoSettings
 {
+	Q_OBJECT
+
 public:
 	VideoSpecSettings() : PhGenericSettings(true) {
 	}

--- a/tests/FormTest/FormTestSettings.h
+++ b/tests/FormTest/FormTestSettings.h
@@ -7,6 +7,8 @@
 
 class FormTestSettings : protected PhGenericSettings, public PhWindowSettings, public PhFeedbackSettings
 {
+	Q_OBJECT
+
 public:
 	// PhWindowSettings
 	PH_SETTING_BOOL(setFullScreen, fullScreen)

--- a/tests/GraphicStripSyncTest/GraphicStripSyncTest.pro
+++ b/tests/GraphicStripSyncTest/GraphicStripSyncTest.pro
@@ -29,6 +29,7 @@ SOURCES += main.cpp \
 
 HEADERS += \
 	../GraphicStripTest/GraphicStripTestWindow.h \
+	../GraphicStripTest/GraphicStripTestSettings.h \
 	../GraphicStripTest/StripPropertiesDialog.h \
 	../GraphicStripTest/GenerateDialog.h \
 	GraphicStripSyncTestWindow.h \

--- a/tests/GraphicStripSyncTest/GraphicStripSyncTestSettings.h
+++ b/tests/GraphicStripSyncTest/GraphicStripSyncTestSettings.h
@@ -10,6 +10,8 @@
 class GraphicStripSyncTestSettings : public GraphicStripTestSettings,
 	public PhSonySettings
 {
+	Q_OBJECT
+
 public:
 	// PhSonySettings:
 	PH_SETTING_BOOL2(setVideoSyncUp, videoSyncUp, true)

--- a/tests/GraphicStripSyncTest/GraphicStripSyncTestSettings.h
+++ b/tests/GraphicStripSyncTest/GraphicStripSyncTestSettings.h
@@ -3,6 +3,7 @@
 
 #include <QDir>
 
+#include "PhSync/PhTimeCode.h"
 #include "PhSony/PhSonySettings.h"
 
 #include "../GraphicStripTest/GraphicStripTestSettings.h"

--- a/tests/GraphicStripTest/GraphicStripTestSettings.h
+++ b/tests/GraphicStripTest/GraphicStripTestSettings.h
@@ -13,6 +13,8 @@ class GraphicStripTestSettings : protected PhGenericSettings,
 	public PhDocumentWindowSettings
 
 {
+	Q_OBJECT
+
 public:
 	PH_SETTING_INT(setScreenDelay, screenDelay)
 

--- a/tests/GraphicSyncTest/GraphicSyncTestSettings.h
+++ b/tests/GraphicSyncTest/GraphicSyncTestSettings.h
@@ -11,6 +11,8 @@
 
 class GraphicSyncTestSettings : PhGenericSettings, public PhSonySettings
 {
+	Q_OBJECT
+
 public:
 	// PhSonySettings:
 	PH_SETTING_BOOL2(setVideoSyncUp, videoSyncUp, true)

--- a/tests/GraphicSyncTest/GraphicSyncTestSettings.h
+++ b/tests/GraphicSyncTest/GraphicSyncTestSettings.h
@@ -6,6 +6,7 @@
 #ifndef GRAPHICSYNCTESTSETTINGS_H
 #define GRAPHICSYNCTESTSETTINGS_H
 
+#include "PhSync/PhTimeCode.h"
 #include "PhTools/PhGenericSettings.h"
 #include "PhSony/PhSonySettings.h"
 

--- a/tests/GraphicTest/GraphicTestSettings.h
+++ b/tests/GraphicTest/GraphicTestSettings.h
@@ -9,6 +9,8 @@
 
 class GraphicTestSettings : public PhGenericSettings, public PhWindowSettings, public PhGraphicSettings
 {
+	Q_OBJECT
+
 public:
 	// PhWindowSettings
 	PH_SETTING_BOOL(setFullScreen, fullScreen)

--- a/tests/StripTest/StripTestSettings.h
+++ b/tests/StripTest/StripTestSettings.h
@@ -5,6 +5,8 @@
 
 class StripTestSettings : protected PhGenericSettings
 {
+	Q_OBJECT
+
 public:
 	PH_SETTING_INT2(setLogMask, logMask, 1);
 };

--- a/tests/TextEditTest/TextEditTestSettings.h
+++ b/tests/TextEditTest/TextEditTestSettings.h
@@ -8,6 +8,8 @@
 
 class TextEditTestSettings : protected PhGenericSettings, public PhDocumentWindowSettings
 {
+	Q_OBJECT
+
 public:
 	// PhWindowSettings
 	PH_SETTING_BOOL(setFullScreen, fullScreen)

--- a/tests/VideoStripTest/VideoStripTestSettings.h
+++ b/tests/VideoStripTest/VideoStripTestSettings.h
@@ -14,6 +14,8 @@ class VideoStripTestSettings : PhGenericSettings,
 	public PhVideoSettings,
 	public PhDocumentWindowSettings
 {
+	Q_OBJECT
+
 public:
 	PH_SETTING_INT(setScreenDelay, screenDelay)
 

--- a/tests/VideoSyncTest/VideoSyncTestSettings.h
+++ b/tests/VideoSyncTest/VideoSyncTestSettings.h
@@ -10,6 +10,8 @@
 class VideoSyncTestSettings : public VideoTestSettings,
 	public PhSonySettings
 {
+	Q_OBJECT
+
 public:
 	// PhSonySettings:
 	PH_SETTING_BOOL2(setVideoSyncUp, videoSyncUp, true)

--- a/tests/VideoTest/VideoTestSettings.h
+++ b/tests/VideoTest/VideoTestSettings.h
@@ -15,6 +15,8 @@ class VideoTestSettings : protected PhGenericSettings,
 	public PhVideoSettings,
 	public PhDocumentWindowSettings
 {
+	Q_OBJECT
+
 public:
 	PH_SETTING_INT(setScreenDelay, screenDelay)
 	PH_SETTING_INT2(setLogMask, logMask, 1)


### PR DESCRIPTION
Dear Martin,

This PR contains 2 commits that significantly improve the performance of reading from and writing to the settings. Profiling has shown that those operations are very costly, at least on Windows, because Qt always reads and writes from the settings' persistent location (a file or the Windows registry).

The first commit introduces an in-memory cache of the settings (a QMap for each type). Each setting is loaded from the persistent location the first time it is read. When the setter is used, the cache and the persistent location are only updated if there is a real change.

I've taken the opportunity to add signal and properties to each setting, which makes them reachable from QML. This is essential for what is done in the branch here: https://github.com/tlecomte/Joker/tree/tlQMLRebase
If you accept this addition, this will reduce the delta between master and this branch.

Finally, the second commit avoids saving the time played to the settings persistent location on every tick of the clock, which is very costly. Instead it is saved in memory, and saved to the persistent location when Joker is closed.

Thanks for considering this PR!