### PR TITLE
Update ffmpeg windows binaries

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,13 +14,13 @@ install:
   # Configuring Qt
   - set PATH=%QTDIR%\bin;C:\Qt\Tools\mingw491_32\bin;%PATH%
   # Installing ffmpeg dev
-  - curl -kLO https://ffmpeg.zeranoe.com/builds/win32/dev/ffmpeg-20160622-e0faad8-win32-dev.zip
-  - 7z x ffmpeg-20160622-e0faad8-win32-dev.zip
-  - set FFMPEG_DEV_PATH=%CD%\ffmpeg-20160622-e0faad8-win32-dev
+  - curl -kLO https://ffmpeg.zeranoe.com/builds/win32/dev/ffmpeg-3.3.1-win32-dev.zip
+  - 7z x ffmpeg-3.3.1-win32-dev.zip
+  - set FFMPEG_DEV_PATH=%CD%\ffmpeg-3.3.1-win32-dev
   # Installing ffmpeg shared
-  - curl -kLO https://ffmpeg.zeranoe.com/builds/win32/shared/ffmpeg-20160622-e0faad8-win32-shared.zip
-  - 7z x ffmpeg-20160622-e0faad8-win32-shared.zip
-  - set FFMPEG_SHARED_PATH=%CD%\ffmpeg-20160622-e0faad8-win32-shared
+  - curl -kLO https://ffmpeg.zeranoe.com/builds/win32/shared/ffmpeg-3.3.1-win32-shared.zip
+  - 7z x ffmpeg-3.3.1-win32-shared.zip
+  - set FFMPEG_SHARED_PATH=%CD%\ffmpeg-3.3.1-win32-shared
   # Installing PortAudio
   - curl -kLO https://github.com/adfernandes/precompiled-portaudio-windows/raw/master/portaudio-r1891-build.zip
   - 7z x portaudio-r1891-build.zip


### PR DESCRIPTION
Dear Martin,

ffmpeg-20160622-e0faad8-win32-dev.zip is no longer available on the Zeranoe repository, which makes the Appveyor build fail. This PR upgrades to ffmpeg-3.3.1-win32-dev.zip

Thanks for considering this request !

