### PR TITLE
Add preference combobox to setup the LTC timecode

### DIFF
--- a/app/Joker/JokerWindow.cpp
+++ b/app/Joker/JokerWindow.cpp
@@ -226,6 +226,7 @@ void JokerWindow::setupSyncProtocol()
 #endif
 	case PhSynchronizer::LTC:
 #ifdef USE_LTC
+		_ltcReader.setTimeCodeType((PhTimeCodeType)_settings->ltcReaderTimeCodeType());
 		if(_ltcReader.init(_settings->ltcInputPort()))
 			clock = _ltcReader.clock();
 		else {
@@ -1013,6 +1014,7 @@ void JokerWindow::on_actionPreferences_triggered()
 	int oldSynchroProtocol = _settings->synchroProtocol();
 #ifdef USE_LTC
 	QString oldLtcInputPort = _settings->ltcInputPort();
+	PhTimeCodeType oldLtcTimeCodeType = (PhTimeCodeType)_settings->ltcReaderTimeCodeType();
 #endif // USE_LTC
 #ifdef USE_MIDI
 	QString oldMtcInputPort = _settings->mtcInputPort();
@@ -1026,7 +1028,8 @@ void JokerWindow::on_actionPreferences_triggered()
 	if(dlg.exec() == QDialog::Accepted) {
 		if((oldSynchroProtocol != _settings->synchroProtocol())
 #ifdef USE_LTC
-		   || (oldLtcInputPort  != _settings->ltcInputPort())
+		   || (oldLtcInputPort != _settings->ltcInputPort())
+		   || (oldLtcTimeCodeType != (PhTimeCodeType)_settings->ltcReaderTimeCodeType())
 #endif // USE_LTC
 #ifdef USE_MIDI
 		   || (oldMtcInputPort != _settings->mtcInputPort())

--- a/app/Joker/PreferencesDialog.cpp
+++ b/app/Joker/PreferencesDialog.cpp
@@ -95,6 +95,7 @@ PreferencesDialog::PreferencesDialog(JokerSettings *settings, QWidget *parent) :
 	ui->ltcInputPortComboBox->addItems(ltcInputPorts);
 	if(ltcInputPorts.contains(_settings->ltcInputPort()))
 		ui->ltcInputPortComboBox->setCurrentText(_settings->ltcInputPort());
+	ui->ltcTimeCodeTypeComboBox->setCurrentIndex(_settings->ltcReaderTimeCodeType());
 #else
 	ui->ltcRadioButton->setEnabled(false);
 #endif
@@ -208,6 +209,7 @@ void PreferencesDialog::accept()
 #endif
 #ifdef USE_LTC
 	_settings->setLtcInputPort(ui->ltcInputPortComboBox->currentText());
+	_settings->setLtcReaderTimeCodeType(ui->ltcTimeCodeTypeComboBox->currentIndex());
 #endif
 
 #ifdef USE_MIDI

--- a/app/Joker/PreferencesDialog.ui
+++ b/app/Joker/PreferencesDialog.ui
@@ -20,7 +20,7 @@
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>2</number>
      </property>
      <widget class="QWidget" name="tabGeneral">
       <attribute name="title">
@@ -352,16 +352,49 @@
           <enum>QFrame::Raised</enum>
          </property>
          <layout class="QFormLayout" name="formLayout_2">
-          <property name="fieldGrowthPolicy">
-           <enum>QFormLayout::FieldsStayAtSizeHint</enum>
-          </property>
-          <item row="0" column="1">
-           <widget class="QComboBox" name="ltcInputPortComboBox"/>
-          </item>
-          <item row="0" column="0">
+          <item row="3" column="0">
            <widget class="QLabel" name="ltcInputPortLabel">
             <property name="text">
              <string>Audio input port:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QComboBox" name="ltcInputPortComboBox"/>
+          </item>
+          <item row="4" column="1">
+           <widget class="QComboBox" name="ltcTimeCodeTypeComboBox">
+            <item>
+             <property name="text">
+              <string>23.98 fps</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>24 fps</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>25 fps</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>29.97 fps</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>30 fps</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="ltcTimeCodeTypeLabel">
+            <property name="text">
+             <string>Timecode type:</string>
             </property>
            </widget>
           </item>

--- a/libs/PhLtc/PhLtcReader.cpp
+++ b/libs/PhLtc/PhLtcReader.cpp
@@ -37,6 +37,10 @@ PhTimeCodeType PhLtcReader::timeCodeType()
 	return _tcType;
 }
 
+void PhLtcReader::setTimeCodeType(PhTimeCodeType tcType) {
+	updateTCType(tcType);
+}
+
 int PhLtcReader::processAudio(const void *inputBuffer, void *, unsigned long framesPerBuffer)
 {
 	ltc_decoder_write_s16(_decoder, (short*)inputBuffer, framesPerBuffer, _position);

--- a/libs/PhLtc/PhLtcReader.h
+++ b/libs/PhLtc/PhLtcReader.h
@@ -48,6 +48,13 @@ public:
 	 */
 	PhTimeCodeType timeCodeType();
 
+public slots:
+	/**
+	 * @brief Handle a timecode type change
+	 * @param tcType the new timecode type
+	 */
+	void setTimeCodeType(PhTimeCodeType tcType);
+
 signals:
 	/**
 	 * @brief Emit a signal when the timecodeType change

--- a/libs/PhVideo/PhVideoDecoder.cpp
+++ b/libs/PhVideo/PhVideoDecoder.cpp
@@ -280,6 +280,10 @@ void PhVideoDecoder::stop()
 
 bool PhVideoDecoder::canDecode()
 {
+	if (_videoStream == NULL) {
+		return false;
+	}
+
 	if (_stripFrame == PHFRAMEMIN) {
 		return false;
 	}

--- a/scripts/install_qt.sh
+++ b/scripts/install_qt.sh
@@ -17,7 +17,7 @@ export QMAKESPEC=macx-clang
 elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
 echo "Linux detected"
 
-sudo add-apt-repository -y ppa:beineri/opt-qt${QTVER}
+sudo add-apt-repository -y ppa:beineri/opt-qt${QTVER}-trusty
 sudo apt-get -qy update
 
 sudo apt-get -qy install qt${SHORT_VER}base qt${SHORT_VER}xmlpatterns libboost-all-dev


### PR DESCRIPTION
Dear Martin, this PR adds a combobox in the settings to force a specific LTC timecode. This has proved very useful to ensure proper sync between the audio workstation and the video.

Thanks for considering this PR!