### PR TITLE
Fix Windows build separator

### DIFF
--- a/app/Joker/Joker.pro
+++ b/app/Joker/Joker.pro
@@ -115,7 +115,7 @@ include($$TOP_ROOT/common/deploy.pri)
 
 cache()
 
-QMAKE_POST_LINK += echo "Joker build ok" $${CS}
+QMAKE_POST_LINK += echo "Joker build ok"
 
 RESOURCES += \
 	Joker.qrc

--- a/common/common.pri
+++ b/common/common.pri
@@ -54,7 +54,7 @@ DEFINES += PATH_TO_RESSOURCES=\\\"\\\"
 
 # Windows specific
 win32 {
-	CS = &
+	CS = &&
 	CONFIG(release, debug|release) {
 		RESOURCES_PATH = $$shell_path(./release/)
 	}


### PR DESCRIPTION
Dear Martin, this PR contains a small improvement for the Windows build. It replaces & by &&. This avoids cases where one command would fail but the build would continue anyway because of the use of & only.

Thanks for considering this PR!