### PR TITLE
Prevent document reloading when saving

### DIFF
--- a/app/Joker/JokerWindow.cpp
+++ b/app/Joker/JokerWindow.cpp
@@ -315,12 +315,28 @@ bool JokerWindow::openDocument(const QString &fileName)
 
 void JokerWindow::saveDocument(const QString &fileName)
 {
+	// prevent from reloading the document when we are the ones changing it
+	bool updateWatcher;
+	if (_watcher.files().contains(fileName)) {
+		_watcher.removePath(_doc->filePath());
+		updateWatcher = true;
+	}
+
 	if(_doc->exportDetXFile(fileName, currentTime())) {
 		_doc->setModified(false);
 		PhEditableDocumentWindow::saveDocument(fileName);
+
+		if (updateWatcher) {
+			_watcher.addPath(fileName);
+		}
 	}
-	else
+	else {
+		if (updateWatcher) {
+			_watcher.addPath(fileName);
+		}
+
 		QMessageBox::critical(this, "", QString(tr("Unable to save %1")).arg(fileName));
+	}
 }
 
 void JokerWindow::onExternalChange(const QString &path)


### PR DESCRIPTION
Dear Martin, this PR is about a small enhancement to the file watcher. It makes sure the watcher ignores the file change when Joker itself is responsible for the change during saving. This particularly makes sense in the context of the changes related to edition in this branch: https://github.com/tlecomte/Joker/tree/tlQMLRebase

Thanks !